### PR TITLE
[codex] fix Android Chromecast playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,50 @@ npm install @capgo/capacitor-video-player
 npx cap sync
 ```
 
+## Supported Features
+
+| Feature                        | iOS | Android | Web |
+| ------------------------------ | --- | ------- | --- |
+| Fullscreen native video player | ✅  | ✅      | ❌  |
+| Embedded web video player      | ❌  | ❌      | ✅  |
+| Picture in Picture             | ✅  | ✅      | ❌  |
+| Subtitles                      | ✅  | ✅      | ✅  |
+| DRM-protected playback         | ✅  | ✅      | ❌  |
+| Chromecast sender playback     | ❌  | ✅      | ❌  |
+
+## Chromecast (Android)
+
+Chromecast is supported on Android in fullscreen mode. Enable it with the `chromecast` option. When a Cast session starts, the plugin loads the same media URL on the receiver, keeps the current playback position, and routes play, pause, seek, and timeline controls through the Cast session.
+
+```ts
+await VideoPlayer.initPlayer({
+  mode: 'fullscreen',
+  playerId: 'main-player',
+  url: 'https://example.com/video.m3u8',
+  title: 'Video title',
+  smallTitle: 'Optional subtitle',
+  artwork: 'https://example.com/artwork.jpg',
+  chromecast: true,
+  showControls: true,
+});
+```
+
+### Chromecast Options
+
+| Option       | Type      | Default | Description                                                |
+| ------------ | --------- | ------- | ---------------------------------------------------------- |
+| `chromecast` | `boolean` | `true`  | Shows the Android Cast button and enables sender playback. |
+| `title`      | `string`  | `""`    | Title shown in the sender controls and receiver metadata.  |
+| `smallTitle` | `string`  | `""`    | Subtitle shown in the sender controls and metadata.        |
+| `artwork`    | `string`  | `""`    | Image URL used for Cast metadata and sender Cast artwork.  |
+
+### Requirements and Notes
+
+- The media URL must be reachable by the Chromecast device, not only by the Android app.
+- Cast support depends on the receiver app and device media support. MP4, HLS, DASH, and SmoothStreaming streams are mapped to Cast-compatible MIME types by the plugin.
+- Widevine DRM metadata is forwarded to the Cast media item. DRM-protected streams may still require a receiver that supports your license server and DRM flow.
+- Request headers used by the Android local player are not automatically available to the Chromecast receiver. Use public URLs, signed URLs, cookies supported by your receiver, or a custom receiver for secured media.
+
 ## API
 
 <docgen-index>

--- a/android/src/main/java/com/capgo/videoplayer/FullscreenExoPlayerFragment.java
+++ b/android/src/main/java/com/capgo/videoplayer/FullscreenExoPlayerFragment.java
@@ -56,6 +56,8 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.ext.cast.CastPlayer;
+import com.google.android.exoplayer2.ext.cast.DefaultMediaItemConverter;
+import com.google.android.exoplayer2.ext.cast.MediaItemConverter;
 import com.google.android.exoplayer2.ext.cast.SessionAvailabilityListener;
 import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector;
 import com.google.android.exoplayer2.source.MediaSource;
@@ -79,16 +81,21 @@ import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.util.MimeTypes;
+import com.google.android.gms.cast.MediaInfo;
+import com.google.android.gms.cast.MediaQueueItem;
+import com.google.android.gms.cast.MediaTrack;
 import com.google.android.gms.cast.framework.CastButtonFactory;
 import com.google.android.gms.cast.framework.CastContext;
 import com.google.android.gms.cast.framework.CastState;
 import com.google.android.gms.cast.framework.CastStateListener;
+import com.google.android.gms.common.images.WebImage;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -97,6 +104,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 public class FullscreenExoPlayerFragment extends Fragment {
 
@@ -995,18 +1003,7 @@ public class FullscreenExoPlayerFragment extends Fragment {
         mediaSources[0] = mediaSource;
         String mimeType = getMimeType(sturi);
 
-        // We get the language label from the language code
-        String languageLabel = Locale.forLanguageTag(language).getDisplayLanguage();
-        MediaItem.SubtitleConfiguration subConfig = new MediaItem.SubtitleConfiguration.Builder(sturi)
-            .setMimeType(mimeType)
-            .setUri(sturi)
-            .setId(subTitle)
-            .setLabel(languageLabel)
-            .setRoleFlags(C.ROLE_FLAG_CAPTION)
-            .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
-            .setLanguage(language)
-            .build();
-
+        MediaItem.SubtitleConfiguration subConfig = buildSubtitleConfiguration(sturi, mimeType);
         SingleSampleMediaSource subtitleSource = new SingleSampleMediaSource.Factory(dataSourceFactory).createMediaSource(
             subConfig,
             C.TIME_UNSET
@@ -1330,7 +1327,7 @@ public class FullscreenExoPlayerFragment extends Fragment {
                 public void onComplete(Task<CastContext> task) {
                     if (task.isSuccessful()) {
                         castContext = task.getResult();
-                        castPlayer = new CastPlayer(castContext);
+                        castPlayer = new CastPlayer(castContext, new SubtitleMediaItemConverter());
                         mRouter = MediaRouter.getInstance(context);
                         mSelector = new MediaRouteSelector.Builder()
                             .addControlCategories(
@@ -1362,6 +1359,16 @@ public class FullscreenExoPlayerFragment extends Fragment {
                             new SessionAvailabilityListener() {
                                 @Override
                                 public void onCastSessionAvailable() {
+                                    Uri castUri = getCastUri();
+                                    if (!isNetworkUri(castUri)) {
+                                        Toast.makeText(
+                                            context,
+                                            "Chromecast requires a network-reachable media URL",
+                                            Toast.LENGTH_SHORT
+                                        ).show();
+                                        castContext.getSessionManager().endCurrentSession(false);
+                                        return;
+                                    }
                                     isCastSession = true;
                                     final Long videoPosition = player.getCurrentPosition();
                                     final boolean shouldPlay = player.getPlayWhenReady();
@@ -1372,7 +1379,7 @@ public class FullscreenExoPlayerFragment extends Fragment {
                                     player.setPlayWhenReady(false);
                                     cast_image.setVisibility(View.VISIBLE);
                                     styledPlayerView.setPlayer(castPlayer);
-                                    castPlayer.setMediaItem(buildCastMediaItem(), videoPosition);
+                                    castPlayer.setMediaItem(buildCastMediaItem(castUri), videoPosition);
                                     castPlayer.setPlayWhenReady(shouldPlay);
                                     castPlayer.prepare();
                                     styledPlayerView.setControllerShowTimeoutMs(0);
@@ -1383,6 +1390,7 @@ public class FullscreenExoPlayerFragment extends Fragment {
 
                                 @Override
                                 public void onCastSessionUnavailable() {
+                                    if (!isCastSession) return;
                                     isCastSession = false;
                                     final Long videoPosition = castPlayer.getCurrentPosition();
                                     final boolean shouldPlay = castPlayer.getPlayWhenReady();
@@ -1440,13 +1448,25 @@ public class FullscreenExoPlayerFragment extends Fragment {
 
     private final class EmptyCallback extends MediaRouter.Callback {}
 
-    private MediaItem buildCastMediaItem() {
-        Uri castUri = uri != null ? uri : Uri.parse(videoPath);
-        return buildMediaItem(castUri)
-            .buildUpon()
-            .setMimeType(getMediaItemMimeType(castUri))
-            .setMediaMetadata(buildCastMediaMetadata())
-            .build();
+    private Uri getCastUri() {
+        return uri != null ? uri : Uri.parse(videoPath);
+    }
+
+    private boolean isNetworkUri(Uri mediaUri) {
+        String scheme = mediaUri.getScheme();
+        return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+    }
+
+    private MediaItem buildCastMediaItem(Uri castUri) {
+        MediaItem.Builder builder = buildMediaItem(castUri).buildUpon().setMediaMetadata(buildCastMediaMetadata());
+        String mimeType = getMediaItemMimeType(castUri);
+        if (mimeType != null) {
+            builder.setMimeType(mimeType);
+        }
+        if (sturi != null && isNetworkUri(sturi)) {
+            builder.setSubtitleConfigurations(Arrays.asList(buildSubtitleConfiguration(sturi, getMimeType(sturi))));
+        }
+        return builder.build();
     }
 
     private MediaMetadata buildCastMediaMetadata() {
@@ -1459,6 +1479,19 @@ public class FullscreenExoPlayerFragment extends Fragment {
 
     private boolean hasArtwork() {
         return artwork != null && !artwork.isEmpty();
+    }
+
+    private MediaItem.SubtitleConfiguration buildSubtitleConfiguration(Uri subtitleUri, String mimeType) {
+        String languageLabel = Locale.forLanguageTag(language).getDisplayLanguage();
+        return new MediaItem.SubtitleConfiguration.Builder(subtitleUri)
+            .setMimeType(mimeType)
+            .setUri(subtitleUri)
+            .setId(subTitle)
+            .setLabel(languageLabel)
+            .setRoleFlags(C.ROLE_FLAG_CAPTION)
+            .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
+            .setLanguage(language)
+            .build();
     }
 
     private String getMediaItemMimeType(Uri mediaUri) {
@@ -1480,10 +1513,193 @@ public class FullscreenExoPlayerFragment extends Fragment {
             case "flv":
                 return "video/x-flv";
             case "mp4":
+                return MimeTypes.VIDEO_MP4;
             case "ytube":
             case "":
             default:
-                return MimeTypes.VIDEO_MP4;
+                return null;
+        }
+    }
+
+    private final class SubtitleMediaItemConverter implements MediaItemConverter {
+
+        private static final String KEY_MEDIA_ITEM = "mediaItem";
+        private static final String KEY_PLAYER_CONFIG = "exoPlayerConfig";
+        private static final String KEY_MEDIA_ID = "mediaId";
+        private static final String KEY_URI = "uri";
+        private static final String KEY_TITLE = "title";
+        private static final String KEY_MIME_TYPE = "mimeType";
+        private static final String KEY_DRM_CONFIGURATION = "drmConfiguration";
+        private static final String KEY_UUID = "uuid";
+        private static final String KEY_LICENSE_URI = "licenseUri";
+        private static final String KEY_REQUEST_HEADERS = "requestHeaders";
+
+        private final DefaultMediaItemConverter defaultConverter = new DefaultMediaItemConverter();
+
+        @Override
+        public MediaQueueItem toMediaQueueItem(MediaItem mediaItem) {
+            MediaItem.LocalConfiguration localConfiguration = mediaItem.localConfiguration;
+            if (localConfiguration == null) {
+                throw new IllegalArgumentException("The item must specify its local configuration");
+            }
+
+            MediaInfo.Builder mediaInfoBuilder = new MediaInfo.Builder(getContentId(mediaItem, localConfiguration))
+                .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
+                .setContentUrl(localConfiguration.uri.toString())
+                .setMetadata(buildCastMediaInfoMetadata(mediaItem))
+                .setCustomData(buildCastCustomData(mediaItem));
+
+            if (localConfiguration.mimeType != null) {
+                mediaInfoBuilder.setContentType(localConfiguration.mimeType);
+            }
+
+            ArrayList<Long> activeTrackIds = new ArrayList<>();
+            List<MediaTrack> mediaTracks = buildCastSubtitleTracks(localConfiguration.subtitleConfigurations, activeTrackIds);
+            if (!mediaTracks.isEmpty()) {
+                mediaInfoBuilder.setMediaTracks(mediaTracks);
+            }
+
+            MediaQueueItem.Builder mediaQueueItemBuilder = new MediaQueueItem.Builder(mediaInfoBuilder.build());
+            if (!activeTrackIds.isEmpty()) {
+                mediaQueueItemBuilder.setActiveTrackIds(toLongArray(activeTrackIds));
+            }
+            return mediaQueueItemBuilder.build();
+        }
+
+        @Override
+        public MediaItem toMediaItem(MediaQueueItem mediaQueueItem) {
+            return defaultConverter.toMediaItem(mediaQueueItem);
+        }
+
+        private String getContentId(MediaItem mediaItem, MediaItem.LocalConfiguration localConfiguration) {
+            return mediaItem.mediaId.equals(MediaItem.DEFAULT_MEDIA_ID) ? localConfiguration.uri.toString() : mediaItem.mediaId;
+        }
+
+        private com.google.android.gms.cast.MediaMetadata buildCastMediaInfoMetadata(MediaItem mediaItem) {
+            MediaItem.LocalConfiguration localConfiguration = mediaItem.localConfiguration;
+            String mimeType = localConfiguration != null ? localConfiguration.mimeType : null;
+            com.google.android.gms.cast.MediaMetadata metadata = new com.google.android.gms.cast.MediaMetadata(
+                mimeType != null && MimeTypes.isAudio(mimeType)
+                    ? com.google.android.gms.cast.MediaMetadata.MEDIA_TYPE_MUSIC_TRACK
+                    : com.google.android.gms.cast.MediaMetadata.MEDIA_TYPE_MOVIE
+            );
+
+            if (mediaItem.mediaMetadata.title != null) {
+                metadata.putString(com.google.android.gms.cast.MediaMetadata.KEY_TITLE, mediaItem.mediaMetadata.title.toString());
+            }
+            if (mediaItem.mediaMetadata.subtitle != null) {
+                metadata.putString(com.google.android.gms.cast.MediaMetadata.KEY_SUBTITLE, mediaItem.mediaMetadata.subtitle.toString());
+            }
+            if (mediaItem.mediaMetadata.artworkUri != null) {
+                metadata.addImage(new WebImage(mediaItem.mediaMetadata.artworkUri));
+            }
+            return metadata;
+        }
+
+        private List<MediaTrack> buildCastSubtitleTracks(
+            List<MediaItem.SubtitleConfiguration> subtitleConfigurations,
+            ArrayList<Long> activeTrackIds
+        ) {
+            ArrayList<MediaTrack> mediaTracks = new ArrayList<>();
+            for (int i = 0; i < subtitleConfigurations.size(); i++) {
+                MediaItem.SubtitleConfiguration subtitleConfiguration = subtitleConfigurations.get(i);
+                if (subtitleConfiguration.uri == null) {
+                    continue;
+                }
+                long trackId = i + 1L;
+                MediaTrack.Builder trackBuilder = new MediaTrack.Builder(trackId, MediaTrack.TYPE_TEXT)
+                    .setContentId(subtitleConfiguration.uri.toString())
+                    .setSubtype(MediaTrack.SUBTYPE_SUBTITLES);
+                if (subtitleConfiguration.mimeType != null) {
+                    trackBuilder.setContentType(subtitleConfiguration.mimeType);
+                }
+                if (subtitleConfiguration.label != null) {
+                    trackBuilder.setName(subtitleConfiguration.label.toString());
+                }
+                if (subtitleConfiguration.language != null) {
+                    trackBuilder.setLanguage(subtitleConfiguration.language);
+                }
+                mediaTracks.add(trackBuilder.build());
+                if ((subtitleConfiguration.selectionFlags & C.SELECTION_FLAG_DEFAULT) != 0) {
+                    activeTrackIds.add(trackId);
+                }
+            }
+            return mediaTracks;
+        }
+
+        private long[] toLongArray(List<Long> values) {
+            long[] result = new long[values.size()];
+            for (int i = 0; i < values.size(); i++) {
+                result[i] = values.get(i);
+            }
+            return result;
+        }
+
+        private JSONObject buildCastCustomData(MediaItem mediaItem) {
+            try {
+                JSONObject customData = new JSONObject();
+                customData.put(KEY_MEDIA_ITEM, buildMediaItemJson(mediaItem));
+                JSONObject playerConfig = buildPlayerConfigJson(mediaItem);
+                if (playerConfig != null) {
+                    customData.put(KEY_PLAYER_CONFIG, playerConfig);
+                }
+                return customData;
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private JSONObject buildMediaItemJson(MediaItem mediaItem) throws JSONException {
+            MediaItem.LocalConfiguration localConfiguration = mediaItem.localConfiguration;
+            JSONObject json = new JSONObject();
+            json.put(KEY_MEDIA_ID, mediaItem.mediaId);
+            if (mediaItem.mediaMetadata.title != null) {
+                json.put(KEY_TITLE, mediaItem.mediaMetadata.title.toString());
+            }
+            json.put(KEY_URI, localConfiguration.uri.toString());
+            if (localConfiguration.mimeType != null) {
+                json.put(KEY_MIME_TYPE, localConfiguration.mimeType);
+            }
+            if (localConfiguration.drmConfiguration != null) {
+                json.put(KEY_DRM_CONFIGURATION, buildDrmConfigurationJson(localConfiguration.drmConfiguration));
+            }
+            return json;
+        }
+
+        private JSONObject buildDrmConfigurationJson(MediaItem.DrmConfiguration drmConfiguration) throws JSONException {
+            JSONObject json = new JSONObject();
+            json.put(KEY_UUID, drmConfiguration.scheme.toString());
+            json.put(KEY_LICENSE_URI, drmConfiguration.licenseUri.toString());
+            json.put(KEY_REQUEST_HEADERS, new JSONObject(drmConfiguration.licenseRequestHeaders));
+            return json;
+        }
+
+        private JSONObject buildPlayerConfigJson(MediaItem mediaItem) throws JSONException {
+            MediaItem.LocalConfiguration localConfiguration = mediaItem.localConfiguration;
+            if (localConfiguration == null || localConfiguration.drmConfiguration == null) {
+                return null;
+            }
+
+            MediaItem.DrmConfiguration drmConfiguration = localConfiguration.drmConfiguration;
+            String protectionSystem;
+            if (C.WIDEVINE_UUID.equals(drmConfiguration.scheme)) {
+                protectionSystem = "widevine";
+            } else if (C.PLAYREADY_UUID.equals(drmConfiguration.scheme)) {
+                protectionSystem = "playready";
+            } else {
+                return null;
+            }
+
+            JSONObject json = new JSONObject();
+            json.put("withCredentials", false);
+            json.put("protectionSystem", protectionSystem);
+            if (drmConfiguration.licenseUri != null) {
+                json.put("licenseUrl", drmConfiguration.licenseUri.toString());
+            }
+            if (!drmConfiguration.licenseRequestHeaders.isEmpty()) {
+                json.put("headers", new JSONObject(drmConfiguration.licenseRequestHeaders));
+            }
+            return json;
         }
     }
 

--- a/android/src/main/java/com/capgo/videoplayer/FullscreenExoPlayerFragment.java
+++ b/android/src/main/java/com/capgo/videoplayer/FullscreenExoPlayerFragment.java
@@ -188,7 +188,6 @@ public class FullscreenExoPlayerFragment extends Fragment {
     private MediaRouteButton mediaRouteButton;
     private CastContext castContext;
     private CastPlayer castPlayer;
-    private MediaItem mediaItem;
     private MediaRouter mRouter;
     private MediaRouter.Callback mCallback = new EmptyCallback();
     private MediaRouteSelector mSelector;
@@ -1355,23 +1354,9 @@ public class FullscreenExoPlayerFragment extends Fragment {
                         };
                         CastButtonFactory.setUpMediaRouteButton(context, mediaRouteButton);
 
-                        MediaMetadata movieMetadata;
                         if (artwork != "") {
-                            movieMetadata = new MediaMetadata.Builder()
-                                .setTitle(title)
-                                .setSubtitle(smallTitle)
-                                .setMediaType(MediaMetadata.MEDIA_TYPE_MOVIE)
-                                .setArtworkUri(Uri.parse(artwork))
-                                .build();
                             new setCastImage().execute();
-                        } else {
-                            movieMetadata = new MediaMetadata.Builder().setTitle(title).setSubtitle(smallTitle).build();
                         }
-                        mediaItem = new MediaItem.Builder()
-                            .setUri(videoPath)
-                            .setMimeType(MimeTypes.VIDEO_UNKNOWN)
-                            .setMediaMetadata(movieMetadata)
-                            .build();
 
                         castPlayer.setSessionAvailabilityListener(
                             new SessionAvailabilityListener() {
@@ -1379,14 +1364,17 @@ public class FullscreenExoPlayerFragment extends Fragment {
                                 public void onCastSessionAvailable() {
                                     isCastSession = true;
                                     final Long videoPosition = player.getCurrentPosition();
+                                    final boolean shouldPlay = player.getPlayWhenReady();
                                     if (pipEnabled) {
                                         pipBtn.setVisibility(View.GONE);
                                     }
                                     resizeBtn.setVisibility(View.GONE);
                                     player.setPlayWhenReady(false);
                                     cast_image.setVisibility(View.VISIBLE);
-                                    castPlayer.setMediaItem(mediaItem, videoPosition);
                                     styledPlayerView.setPlayer(castPlayer);
+                                    castPlayer.setMediaItem(buildCastMediaItem(), videoPosition);
+                                    castPlayer.setPlayWhenReady(shouldPlay);
+                                    castPlayer.prepare();
                                     styledPlayerView.setControllerShowTimeoutMs(0);
                                     styledPlayerView.setControllerHideOnTouch(false);
                                     //We perform a click because for some weird reason, the layout is black until the user clicks on it
@@ -1397,14 +1385,17 @@ public class FullscreenExoPlayerFragment extends Fragment {
                                 public void onCastSessionUnavailable() {
                                     isCastSession = false;
                                     final Long videoPosition = castPlayer.getCurrentPosition();
+                                    final boolean shouldPlay = castPlayer.getPlayWhenReady();
                                     if (pipEnabled) {
                                         pipBtn.setVisibility(View.VISIBLE);
                                     }
                                     resizeBtn.setVisibility(View.VISIBLE);
                                     cast_image.setVisibility(View.GONE);
+                                    castPlayer.stop();
+                                    castPlayer.clearMediaItems();
                                     styledPlayerView.setPlayer(player);
-                                    player.setPlayWhenReady(true);
                                     player.seekTo(videoPosition);
+                                    player.setPlayWhenReady(shouldPlay);
                                     styledPlayerView.setControllerShowTimeoutMs(3000);
                                     styledPlayerView.setControllerHideOnTouch(true);
                                 }
@@ -1418,7 +1409,7 @@ public class FullscreenExoPlayerFragment extends Fragment {
                                     Map<String, Object> info = new HashMap<String, Object>() {
                                         {
                                             put("fromPlayerId", playerId);
-                                            put("currentTime", String.valueOf(player.getCurrentPosition() / 1000));
+                                            put("currentTime", String.valueOf(castPlayer.getCurrentPosition() / 1000));
                                         }
                                     };
                                     switch (state) {
@@ -1448,6 +1439,49 @@ public class FullscreenExoPlayerFragment extends Fragment {
     }
 
     private final class EmptyCallback extends MediaRouter.Callback {}
+
+    private MediaItem buildCastMediaItem() {
+        Uri castUri = uri != null ? uri : Uri.parse(videoPath);
+        return buildMediaItem(castUri)
+            .buildUpon()
+            .setMimeType(getMediaItemMimeType(castUri))
+            .setMediaMetadata(buildCastMediaMetadata())
+            .build();
+    }
+
+    private MediaMetadata buildCastMediaMetadata() {
+        MediaMetadata.Builder metadataBuilder = new MediaMetadata.Builder().setTitle(title).setSubtitle(smallTitle);
+        if (artwork != "") {
+            metadataBuilder.setMediaType(MediaMetadata.MEDIA_TYPE_MOVIE).setArtworkUri(Uri.parse(artwork));
+        }
+        return metadataBuilder.build();
+    }
+
+    private String getMediaItemMimeType(Uri mediaUri) {
+        String mediaType = vType != null ? vType : getVideoType(mediaUri);
+        switch (mediaType) {
+            case "dash":
+            case "mpd":
+                return MimeTypes.APPLICATION_MPD;
+            case "m3u8":
+                return MimeTypes.APPLICATION_M3U8;
+            case "ism":
+                return MimeTypes.APPLICATION_SS;
+            case "webm":
+                return MimeTypes.VIDEO_WEBM;
+            case "ogv":
+                return "video/ogg";
+            case "3gp":
+                return "video/3gpp";
+            case "flv":
+                return "video/x-flv";
+            case "mp4":
+            case "ytube":
+            case "":
+            default:
+                return MimeTypes.VIDEO_MP4;
+        }
+    }
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {

--- a/android/src/main/java/com/capgo/videoplayer/FullscreenExoPlayerFragment.java
+++ b/android/src/main/java/com/capgo/videoplayer/FullscreenExoPlayerFragment.java
@@ -1354,7 +1354,7 @@ public class FullscreenExoPlayerFragment extends Fragment {
                         };
                         CastButtonFactory.setUpMediaRouteButton(context, mediaRouteButton);
 
-                        if (artwork != "") {
+                        if (hasArtwork()) {
                             new setCastImage().execute();
                         }
 
@@ -1451,10 +1451,14 @@ public class FullscreenExoPlayerFragment extends Fragment {
 
     private MediaMetadata buildCastMediaMetadata() {
         MediaMetadata.Builder metadataBuilder = new MediaMetadata.Builder().setTitle(title).setSubtitle(smallTitle);
-        if (artwork != "") {
+        if (hasArtwork()) {
             metadataBuilder.setMediaType(MediaMetadata.MEDIA_TYPE_MOVIE).setArtworkUri(Uri.parse(artwork));
         }
         return metadataBuilder.build();
+    }
+
+    private boolean hasArtwork() {
+        return artwork != null && !artwork.isEmpty();
     }
 
     private String getMediaItemMimeType(Uri mediaUri) {


### PR DESCRIPTION
## What
- Fix Android Chromecast handoff so the receiver loads and starts the selected media from the current position.
- Add README support matrix and Android Chromecast usage documentation.

## Why
- Fixes #27. The Cast session could connect while the receiver never received a playable loaded media item, leaving controls inactive.

## How
- Build the Cast media item from the existing media URI, metadata, MIME type, and Widevine DRM config.
- Apply the current playback position and play state to CastPlayer, then prepare the remote player.
- Restore local playback position and play state when the Cast session ends.

## Testing
- `bun run verify:android`
- `bun run clean && bun run docgen && bunx tsc && bunx rollup -c rollup.config.mjs`
- `bun run eslint`
- `bun run prettier -- --check`
- Formatting ran with `bun run eslint -- --fix`, `bun run prettier -- --write`, and `bun run swiftlint -- --fix --format`.

## Not Tested
- Physical Chromecast device validation is not available in this environment.
- `bun run verify:ios` is blocked locally because Xcode does not have the required iOS 26.4 platform installed.
- `bun run swiftlint -- lint` reports pre-existing iOS SwiftLint violations in files not changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Android Chromecast setup and usage guidance, example usage with Cast metadata fields (title, artwork), and notes on URL reachability, receiver/media support, and DRM/security considerations.

* **Bug Fixes**
  * Improved Chromecast session handling to preserve and mirror local play state to Cast.
  * Restored seamless return to local playback when Cast disconnects, and corrected Cast playback position reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->