### PR TITLE
[codex] Add iOS Chromecast support

### DIFF
--- a/CapgoCapacitorVideoPlayer.podspec
+++ b/CapgoCapacitorVideoPlayer.podspec
@@ -13,5 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
+  s.dependency 'google-cast-sdk', '~> 4.8.4'
   s.swift_version = '5.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -10,14 +10,16 @@ let package = Package(
             targets: ["VideoPlayerPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
+        .package(url: "https://github.com/SRGSSR/google-cast-sdk.git", exact: "4.8.4")
     ],
     targets: [
         .target(
             name: "VideoPlayerPlugin",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "GoogleCast", package: "google-cast-sdk")
             ],
             path: "ios/Sources/VideoPlayerPlugin"),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ bunx cap sync
 
 ## iOS Chromecast setup
 
-iOS Chromecast uses the Google Cast SDK. When `chromecast` is enabled, the plugin adds a Cast button over the fullscreen iOS player, loads the current media on the selected receiver, and keeps plugin play/pause/seek/volume calls pointed at the active Cast session.
+iOS Chromecast uses the Google Cast SDK default media receiver. When `chromecast` is enabled, the plugin adds a Cast button over the fullscreen iOS player, loads the current media on the selected receiver, and keeps plugin play/pause/seek/volume calls pointed at the active Cast session.
 
-For Cast discovery on iOS, add local network keys to your app `Info.plist`. Replace `CC1AD845` with your custom receiver app id when you pass `chromecastReceiverAppId`; omit the second service or keep `CC1AD845` when using the Google default media receiver.
+For Cast discovery on iOS, add local network keys to your app `Info.plist`.
 
 ```xml
 <key>NSBonjourServices</key>
@@ -54,7 +54,6 @@ await VideoPlayer.initPlayer({
   smallTitle: 'Video subtitle',
   artwork: 'https://example.com/poster.jpg',
   chromecast: true,
-  chromecastReceiverAppId: 'AABBCCDD',
 });
 ```
 
@@ -374,32 +373,31 @@ Exit player
 
 #### capVideoPlayerOptions
 
-| Prop                          | Type                                                        | Description                                                                                                                                                                           |
-| ----------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`mode`**                    | <code>string</code>                                         | Player mode - "fullscreen" - "embedded" (Web only)                                                                                                                                    |
-| **`url`**                     | <code>string</code>                                         | The url of the video to play                                                                                                                                                          |
-| **`subtitle`**                | <code>string</code>                                         | The url of subtitle associated with the video                                                                                                                                         |
-| **`language`**                | <code>string</code>                                         | The language of subtitle see https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers                                                                                         |
-| **`subtitleOptions`**         | <code><a href="#subtitleoptions">SubTitleOptions</a></code> | SubTitle Options                                                                                                                                                                      |
-| **`playerId`**                | <code>string</code>                                         | Id of DIV Element parent of the player                                                                                                                                                |
-| **`rate`**                    | <code>number</code>                                         | Initial playing rate                                                                                                                                                                  |
-| **`exitOnEnd`**               | <code>boolean</code>                                        | Exit on VideoEnd (iOS, Android) default: true                                                                                                                                         |
-| **`loopOnEnd`**               | <code>boolean</code>                                        | Loop on VideoEnd when exitOnEnd false (iOS, Android) default: false                                                                                                                   |
-| **`pipEnabled`**              | <code>boolean</code>                                        | Picture in Picture Enable (iOS, Android) default: true                                                                                                                                |
-| **`bkmodeEnabled`**           | <code>boolean</code>                                        | Background Mode Enable (iOS, Android) default: true                                                                                                                                   |
-| **`showControls`**            | <code>boolean</code>                                        | Show Controls Enable (iOS, Android) default: true                                                                                                                                     |
-| **`displayMode`**             | <code>string</code>                                         | Display Mode ["all", "portrait", "landscape"] (iOS, Android) default: "all"                                                                                                           |
-| **`componentTag`**            | <code>string</code>                                         | Component Tag or DOM Element Tag (React app)                                                                                                                                          |
-| **`width`**                   | <code>number</code>                                         | Player Width (mode "embedded" only)                                                                                                                                                   |
-| **`height`**                  | <code>number</code>                                         | Player height (mode "embedded" only)                                                                                                                                                  |
-| **`headers`**                 | <code>{ [key: string]: string; }</code>                     | Headers for the request (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                                                                       |
-| **`title`**                   | <code>string</code>                                         | Title shown in the player and Chromecast metadata (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                                             |
-| **`smallTitle`**              | <code>string</code>                                         | Subtitle shown below the title in the player and Chromecast metadata (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                          |
-| **`accentColor`**             | <code>string</code>                                         | ExoPlayer Progress Bar and Spinner color (Android) by Manuel García Marín (https://github.com/PhantomPainX) Must be a valid hex color code default: #FFFFFF                           |
-| **`chromecast`**              | <code>boolean</code>                                        | Chromecast enable/disable (iOS, Android) iOS requires Google Cast SDK setup and local network Info.plist keys. by Manuel García Marín (https://github.com/PhantomPainX) default: true |
-| **`chromecastReceiverAppId`** | <code>string</code>                                         | iOS Chromecast receiver application ID. Defaults to the Google Cast default media receiver when omitted.                                                                              |
-| **`artwork`**                 | <code>string</code>                                         | Artwork url to be shown in Chromecast player (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX) default: ""                                                      |
-| **`drm`**                     | <code><a href="#drmoptions">DrmOptions</a></code>           | DRM configuration for protected content (iOS: FairPlay, Android: Widevine)                                                                                                            |
+| Prop                  | Type                                                        | Description                                                                                                                                                                           |
+| --------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`mode`**            | <code>string</code>                                         | Player mode - "fullscreen" - "embedded" (Web only)                                                                                                                                    |
+| **`url`**             | <code>string</code>                                         | The url of the video to play                                                                                                                                                          |
+| **`subtitle`**        | <code>string</code>                                         | The url of subtitle associated with the video                                                                                                                                         |
+| **`language`**        | <code>string</code>                                         | The language of subtitle see https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers                                                                                         |
+| **`subtitleOptions`** | <code><a href="#subtitleoptions">SubTitleOptions</a></code> | SubTitle Options                                                                                                                                                                      |
+| **`playerId`**        | <code>string</code>                                         | Id of DIV Element parent of the player                                                                                                                                                |
+| **`rate`**            | <code>number</code>                                         | Initial playing rate                                                                                                                                                                  |
+| **`exitOnEnd`**       | <code>boolean</code>                                        | Exit on VideoEnd (iOS, Android) default: true                                                                                                                                         |
+| **`loopOnEnd`**       | <code>boolean</code>                                        | Loop on VideoEnd when exitOnEnd false (iOS, Android) default: false                                                                                                                   |
+| **`pipEnabled`**      | <code>boolean</code>                                        | Picture in Picture Enable (iOS, Android) default: true                                                                                                                                |
+| **`bkmodeEnabled`**   | <code>boolean</code>                                        | Background Mode Enable (iOS, Android) default: true                                                                                                                                   |
+| **`showControls`**    | <code>boolean</code>                                        | Show Controls Enable (iOS, Android) default: true                                                                                                                                     |
+| **`displayMode`**     | <code>string</code>                                         | Display Mode ["all", "portrait", "landscape"] (iOS, Android) default: "all"                                                                                                           |
+| **`componentTag`**    | <code>string</code>                                         | Component Tag or DOM Element Tag (React app)                                                                                                                                          |
+| **`width`**           | <code>number</code>                                         | Player Width (mode "embedded" only)                                                                                                                                                   |
+| **`height`**          | <code>number</code>                                         | Player height (mode "embedded" only)                                                                                                                                                  |
+| **`headers`**         | <code>{ [key: string]: string; }</code>                     | Headers for the request (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                                                                       |
+| **`title`**           | <code>string</code>                                         | Title shown in the player and Chromecast metadata (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                                             |
+| **`smallTitle`**      | <code>string</code>                                         | Subtitle shown below the title in the player and Chromecast metadata (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                          |
+| **`accentColor`**     | <code>string</code>                                         | ExoPlayer Progress Bar and Spinner color (Android) by Manuel García Marín (https://github.com/PhantomPainX) Must be a valid hex color code default: #FFFFFF                           |
+| **`chromecast`**      | <code>boolean</code>                                        | Chromecast enable/disable (iOS, Android) iOS requires Google Cast SDK setup and local network Info.plist keys. by Manuel García Marín (https://github.com/PhantomPainX) default: true |
+| **`artwork`**         | <code>string</code>                                         | Artwork url to be shown in Chromecast player (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX) default: ""                                                      |
+| **`drm`**             | <code><a href="#drmoptions">DrmOptions</a></code>           | DRM configuration for protected content (iOS: FairPlay, Android: Widevine)                                                                                                            |
 
 
 #### SubTitleOptions

--- a/README.md
+++ b/README.md
@@ -25,8 +25,37 @@ The most complete doc is available here: https://capgo.app/docs/plugins/video-pl
 ## Install
 
 ```bash
-npm install @capgo/capacitor-video-player
-npx cap sync
+bun add @capgo/capacitor-video-player
+bunx cap sync
+```
+
+## iOS Chromecast setup
+
+iOS Chromecast uses the Google Cast SDK. When `chromecast` is enabled, the plugin adds a Cast button over the fullscreen iOS player, loads the current media on the selected receiver, and keeps plugin play/pause/seek/volume calls pointed at the active Cast session.
+
+For Cast discovery on iOS, add local network keys to your app `Info.plist`. Replace `CC1AD845` with your custom receiver app id when you pass `chromecastReceiverAppId`; omit the second service or keep `CC1AD845` when using the Google default media receiver.
+
+```xml
+<key>NSBonjourServices</key>
+<array>
+  <string>_googlecast._tcp</string>
+  <string>_CC1AD845._googlecast._tcp</string>
+</array>
+<key>NSLocalNetworkUsageDescription</key>
+<string>$(PRODUCT_NAME) uses the local network to discover Cast-enabled devices on your WiFi network.</string>
+```
+
+```ts
+await VideoPlayer.initPlayer({
+  playerId: 'fullscreen',
+  mode: 'fullscreen',
+  url: 'https://example.com/video.mp4',
+  title: 'Video title',
+  smallTitle: 'Video subtitle',
+  artwork: 'https://example.com/poster.jpg',
+  chromecast: true,
+  chromecastReceiverAppId: 'AABBCCDD',
+});
 ```
 
 ## API
@@ -345,31 +374,32 @@ Exit player
 
 #### capVideoPlayerOptions
 
-| Prop                  | Type                                                        | Description                                                                                                                                                 |
-| --------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`mode`**            | <code>string</code>                                         | Player mode - "fullscreen" - "embedded" (Web only)                                                                                                          |
-| **`url`**             | <code>string</code>                                         | The url of the video to play                                                                                                                                |
-| **`subtitle`**        | <code>string</code>                                         | The url of subtitle associated with the video                                                                                                               |
-| **`language`**        | <code>string</code>                                         | The language of subtitle see https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers                                                               |
-| **`subtitleOptions`** | <code><a href="#subtitleoptions">SubTitleOptions</a></code> | SubTitle Options                                                                                                                                            |
-| **`playerId`**        | <code>string</code>                                         | Id of DIV Element parent of the player                                                                                                                      |
-| **`rate`**            | <code>number</code>                                         | Initial playing rate                                                                                                                                        |
-| **`exitOnEnd`**       | <code>boolean</code>                                        | Exit on VideoEnd (iOS, Android) default: true                                                                                                               |
-| **`loopOnEnd`**       | <code>boolean</code>                                        | Loop on VideoEnd when exitOnEnd false (iOS, Android) default: false                                                                                         |
-| **`pipEnabled`**      | <code>boolean</code>                                        | Picture in Picture Enable (iOS, Android) default: true                                                                                                      |
-| **`bkmodeEnabled`**   | <code>boolean</code>                                        | Background Mode Enable (iOS, Android) default: true                                                                                                         |
-| **`showControls`**    | <code>boolean</code>                                        | Show Controls Enable (iOS, Android) default: true                                                                                                           |
-| **`displayMode`**     | <code>string</code>                                         | Display Mode ["all", "portrait", "landscape"] (iOS, Android) default: "all"                                                                                 |
-| **`componentTag`**    | <code>string</code>                                         | Component Tag or DOM Element Tag (React app)                                                                                                                |
-| **`width`**           | <code>number</code>                                         | Player Width (mode "embedded" only)                                                                                                                         |
-| **`height`**          | <code>number</code>                                         | Player height (mode "embedded" only)                                                                                                                        |
-| **`headers`**         | <code>{ [key: string]: string; }</code>                     | Headers for the request (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                                             |
-| **`title`**           | <code>string</code>                                         | Title shown in the player (Android) by Manuel García Marín (https://github.com/PhantomPainX)                                                                |
-| **`smallTitle`**      | <code>string</code>                                         | Subtitle shown below the title in the player (Android) by Manuel García Marín (https://github.com/PhantomPainX)                                             |
-| **`accentColor`**     | <code>string</code>                                         | ExoPlayer Progress Bar and Spinner color (Android) by Manuel García Marín (https://github.com/PhantomPainX) Must be a valid hex color code default: #FFFFFF |
-| **`chromecast`**      | <code>boolean</code>                                        | Chromecast enable/disable (Android) by Manuel García Marín (https://github.com/PhantomPainX) default: true                                                  |
-| **`artwork`**         | <code>string</code>                                         | Artwork url to be shown in Chromecast player by Manuel García Marín (https://github.com/PhantomPainX) default: ""                                           |
-| **`drm`**             | <code><a href="#drmoptions">DrmOptions</a></code>           | DRM configuration for protected content (iOS: FairPlay, Android: Widevine)                                                                                  |
+| Prop                          | Type                                                        | Description                                                                                                                                                                           |
+| ----------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`mode`**                    | <code>string</code>                                         | Player mode - "fullscreen" - "embedded" (Web only)                                                                                                                                    |
+| **`url`**                     | <code>string</code>                                         | The url of the video to play                                                                                                                                                          |
+| **`subtitle`**                | <code>string</code>                                         | The url of subtitle associated with the video                                                                                                                                         |
+| **`language`**                | <code>string</code>                                         | The language of subtitle see https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers                                                                                         |
+| **`subtitleOptions`**         | <code><a href="#subtitleoptions">SubTitleOptions</a></code> | SubTitle Options                                                                                                                                                                      |
+| **`playerId`**                | <code>string</code>                                         | Id of DIV Element parent of the player                                                                                                                                                |
+| **`rate`**                    | <code>number</code>                                         | Initial playing rate                                                                                                                                                                  |
+| **`exitOnEnd`**               | <code>boolean</code>                                        | Exit on VideoEnd (iOS, Android) default: true                                                                                                                                         |
+| **`loopOnEnd`**               | <code>boolean</code>                                        | Loop on VideoEnd when exitOnEnd false (iOS, Android) default: false                                                                                                                   |
+| **`pipEnabled`**              | <code>boolean</code>                                        | Picture in Picture Enable (iOS, Android) default: true                                                                                                                                |
+| **`bkmodeEnabled`**           | <code>boolean</code>                                        | Background Mode Enable (iOS, Android) default: true                                                                                                                                   |
+| **`showControls`**            | <code>boolean</code>                                        | Show Controls Enable (iOS, Android) default: true                                                                                                                                     |
+| **`displayMode`**             | <code>string</code>                                         | Display Mode ["all", "portrait", "landscape"] (iOS, Android) default: "all"                                                                                                           |
+| **`componentTag`**            | <code>string</code>                                         | Component Tag or DOM Element Tag (React app)                                                                                                                                          |
+| **`width`**                   | <code>number</code>                                         | Player Width (mode "embedded" only)                                                                                                                                                   |
+| **`height`**                  | <code>number</code>                                         | Player height (mode "embedded" only)                                                                                                                                                  |
+| **`headers`**                 | <code>{ [key: string]: string; }</code>                     | Headers for the request (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                                                                       |
+| **`title`**                   | <code>string</code>                                         | Title shown in the player and Chromecast metadata (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                                             |
+| **`smallTitle`**              | <code>string</code>                                         | Subtitle shown below the title in the player and Chromecast metadata (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX)                                          |
+| **`accentColor`**             | <code>string</code>                                         | ExoPlayer Progress Bar and Spinner color (Android) by Manuel García Marín (https://github.com/PhantomPainX) Must be a valid hex color code default: #FFFFFF                           |
+| **`chromecast`**              | <code>boolean</code>                                        | Chromecast enable/disable (iOS, Android) iOS requires Google Cast SDK setup and local network Info.plist keys. by Manuel García Marín (https://github.com/PhantomPainX) default: true |
+| **`chromecastReceiverAppId`** | <code>string</code>                                         | iOS Chromecast receiver application ID. Defaults to the Google Cast default media receiver when omitted.                                                                              |
+| **`artwork`**                 | <code>string</code>                                         | Artwork url to be shown in Chromecast player (iOS, Android) by Manuel García Marín (https://github.com/PhantomPainX) default: ""                                                      |
+| **`drm`**                     | <code><a href="#drmoptions">DrmOptions</a></code>           | DRM configuration for protected content (iOS: FairPlay, Android: Widevine)                                                                                                            |
 
 
 #### SubTitleOptions

--- a/ios/Sources/VideoPlayerPlugin/FullscreenVideoPlayer.swift
+++ b/ios/Sources/VideoPlayerPlugin/FullscreenVideoPlayer.swift
@@ -14,7 +14,6 @@ class FullscreenVideoPlayer: NSObject {
     private var pipEnabled: Bool
     private var showControls: Bool
     private var chromecast: Bool
-    private var chromecastReceiverAppId: String?
     private var title: String?
     private var smallTitle: String?
     private var artwork: String?
@@ -39,7 +38,6 @@ class FullscreenVideoPlayer: NSObject {
         pipEnabled: Bool,
         showControls: Bool,
         chromecast: Bool,
-        chromecastReceiverAppId: String? = nil,
         title: String? = nil,
         smallTitle: String? = nil,
         artwork: String? = nil,
@@ -54,7 +52,6 @@ class FullscreenVideoPlayer: NSObject {
         self.pipEnabled = pipEnabled
         self.showControls = showControls
         self.chromecast = chromecast
-        self.chromecastReceiverAppId = chromecastReceiverAppId
         self.title = title
         self.smallTitle = smallTitle
         self.artwork = artwork
@@ -106,7 +103,6 @@ class FullscreenVideoPlayer: NSObject {
         }
 
         castController = VideoPlayerCastController(
-            receiverAppId: chromecastReceiverAppId,
             videoUrl: videoUrl,
             title: title,
             smallTitle: smallTitle,

--- a/ios/Sources/VideoPlayerPlugin/FullscreenVideoPlayer.swift
+++ b/ios/Sources/VideoPlayerPlugin/FullscreenVideoPlayer.swift
@@ -173,7 +173,7 @@ class FullscreenVideoPlayer: NSObject {
         }
 
         viewController.present(playerVC, animated: true) {
-            self.player?.play()
+            self.play()
             completion()
         }
     }

--- a/ios/Sources/VideoPlayerPlugin/FullscreenVideoPlayer.swift
+++ b/ios/Sources/VideoPlayerPlugin/FullscreenVideoPlayer.swift
@@ -13,6 +13,11 @@ class FullscreenVideoPlayer: NSObject {
     private var loopOnEnd: Bool
     private var pipEnabled: Bool
     private var showControls: Bool
+    private var chromecast: Bool
+    private var chromecastReceiverAppId: String?
+    private var title: String?
+    private var smallTitle: String?
+    private var artwork: String?
     private var rate: Float
     private var timeObserver: Any?
     private var onPlay: (() -> Void)?
@@ -23,8 +28,24 @@ class FullscreenVideoPlayer: NSObject {
     private var fairplayCertificateUrl: String?
     private var fairplayContentKeySpcUrl: String?
     private var contentKeySession: AVContentKeySession?
+    private var castController: VideoPlayerCastController?
 
-    init(playerId: String, url: String, rate: Float, exitOnEnd: Bool, loopOnEnd: Bool, pipEnabled: Bool, showControls: Bool, fairplayCertificateUrl: String? = nil, fairplayContentKeySpcUrl: String? = nil) {
+    init(
+        playerId: String,
+        url: String,
+        rate: Float,
+        exitOnEnd: Bool,
+        loopOnEnd: Bool,
+        pipEnabled: Bool,
+        showControls: Bool,
+        chromecast: Bool,
+        chromecastReceiverAppId: String? = nil,
+        title: String? = nil,
+        smallTitle: String? = nil,
+        artwork: String? = nil,
+        fairplayCertificateUrl: String? = nil,
+        fairplayContentKeySpcUrl: String? = nil
+    ) {
         self.playerId = playerId
         self.videoUrl = url
         self.rate = rate
@@ -32,6 +53,11 @@ class FullscreenVideoPlayer: NSObject {
         self.loopOnEnd = loopOnEnd
         self.pipEnabled = pipEnabled
         self.showControls = showControls
+        self.chromecast = chromecast
+        self.chromecastReceiverAppId = chromecastReceiverAppId
+        self.title = title
+        self.smallTitle = smallTitle
+        self.artwork = artwork
         self.fairplayCertificateUrl = fairplayCertificateUrl
         self.fairplayContentKeySpcUrl = fairplayContentKeySpcUrl
         super.init()
@@ -66,9 +92,27 @@ class FullscreenVideoPlayer: NSObject {
 
         // Picture in Picture support
         playerViewController?.allowsPictureInPicturePlayback = pipEnabled
+        setupChromecast()
 
         // Setup observers
         setupObservers()
+    }
+
+    private func setupChromecast() {
+        guard chromecast,
+              let playerViewController = playerViewController,
+              let player = player else {
+            return
+        }
+
+        castController = VideoPlayerCastController(
+            receiverAppId: chromecastReceiverAppId,
+            videoUrl: videoUrl,
+            title: title,
+            smallTitle: smallTitle,
+            artwork: artwork
+        )
+        castController?.attach(to: playerViewController, player: player)
     }
 
     private func setupObservers() {
@@ -140,6 +184,7 @@ class FullscreenVideoPlayer: NSObject {
 
     func dismiss() {
         let currentTime = getCurrentTime()
+        castController?.detach(stopRemoteMedia: true)
         playerViewController?.dismiss(animated: true) { [weak self] in
             self?.cleanup()
             self?.onExit?(currentTime)
@@ -147,6 +192,8 @@ class FullscreenVideoPlayer: NSObject {
     }
 
     private func cleanup() {
+        castController?.detach(stopRemoteMedia: false)
+        castController = nil
         if let observer = timeObserver {
             player?.removeObserver(self, forKeyPath: "rate")
             player?.removeTimeObserver(observer)
@@ -163,54 +210,91 @@ class FullscreenVideoPlayer: NSObject {
     // MARK: - Playback Control
 
     func play() {
+        if castController?.play() == true {
+            return
+        }
         player?.play()
     }
 
     func pause() {
+        if castController?.pause() == true {
+            return
+        }
         player?.pause()
     }
 
     func isPlaying() -> Bool {
+        if castController?.isCasting == true {
+            return castController?.isPlaying() ?? false
+        }
         guard let player = player else { return false }
         return player.rate > 0
     }
 
     func getDuration() -> Double {
+        if castController?.isCasting == true {
+            return castController?.getDuration() ?? 0
+        }
         guard let duration = playerItem?.duration else { return 0 }
         return CMTimeGetSeconds(duration)
     }
 
     func getCurrentTime() -> Double {
+        if castController?.isCasting == true {
+            return castController?.getCurrentTime() ?? 0
+        }
         guard let currentTime = player?.currentTime() else { return 0 }
         return CMTimeGetSeconds(currentTime)
     }
 
     func setCurrentTime(_ time: Double) {
+        if castController?.setCurrentTime(time) == true {
+            return
+        }
         let cmTime = CMTime(seconds: time, preferredTimescale: 600)
         player?.seek(to: cmTime)
     }
 
     func getVolume() -> Float {
+        if castController?.isCasting == true {
+            return castController?.getVolume() ?? 0
+        }
         return player?.volume ?? 0
     }
 
     func setVolume(_ volume: Float) {
+        if castController?.setVolume(volume) == true {
+            return
+        }
         player?.volume = volume
     }
 
     func getMuted() -> Bool {
+        if castController?.isCasting == true {
+            return castController?.getMuted() ?? false
+        }
         return player?.isMuted ?? false
     }
 
     func setMuted(_ muted: Bool) {
+        if castController?.setMuted(muted) == true {
+            return
+        }
         player?.isMuted = muted
     }
 
     func getRate() -> Float {
+        if castController?.isCasting == true {
+            return castController?.getRate() ?? 0
+        }
         return player?.rate ?? 0
     }
 
     func setRate(_ rate: Float) {
+        if castController?.setRate(rate) == true {
+            self.rate = rate
+            return
+        }
         player?.rate = rate
         self.rate = rate
     }
@@ -278,7 +362,7 @@ extension FullscreenVideoPlayer: AVContentKeySessionDelegate {
             guard let certData = certData else {
                 keyRequest.processContentKeyResponseError(
                     certError ?? NSError(domain: "VideoPlayer", code: -2,
-                                        userInfo: [NSLocalizedDescriptionKey: "Failed to fetch FairPlay certificate"])
+                                         userInfo: [NSLocalizedDescriptionKey: "Failed to fetch FairPlay certificate"])
                 )
                 return
             }

--- a/ios/Sources/VideoPlayerPlugin/FullscreenVideoPlayer.swift
+++ b/ios/Sources/VideoPlayerPlugin/FullscreenVideoPlayer.swift
@@ -108,6 +108,15 @@ class FullscreenVideoPlayer: NSObject {
             smallTitle: smallTitle,
             artwork: artwork
         )
+        castController?.setOnPlay { [weak self] in
+            self?.onPlay?()
+        }
+        castController?.setOnPause { [weak self] in
+            self?.onPause?()
+        }
+        castController?.setOnEnd { [weak self] in
+            self?.handlePlaybackEnded()
+        }
         castController?.attach(to: playerViewController, player: player)
     }
 
@@ -155,7 +164,14 @@ class FullscreenVideoPlayer: NSObject {
     }
 
     @objc private func playerDidFinishPlaying() {
+        handlePlaybackEnded()
+    }
+
+    private func handlePlaybackEnded() {
         if loopOnEnd {
+            if castController?.restartPlayback() == true {
+                return
+            }
             player?.seek(to: .zero)
             player?.play()
         } else if exitOnEnd {

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -7,7 +7,6 @@ import UIKit
 import GoogleCast
 
 final class VideoPlayerCastController: NSObject {
-    private let receiverAppId: String?
     private let videoUrl: String
     private let title: String?
     private let smallTitle: String?
@@ -33,8 +32,7 @@ final class VideoPlayerCastController: NSObject {
         return GCKCastContext.sharedInstance().sessionManager.currentCastSession?.remoteMediaClient
     }
 
-    init(receiverAppId: String?, videoUrl: String, title: String?, smallTitle: String?, artwork: String?) {
-        self.receiverAppId = receiverAppId
+    init(videoUrl: String, title: String?, smallTitle: String?, artwork: String?) {
         self.videoUrl = videoUrl
         self.title = title
         self.smallTitle = smallTitle
@@ -48,7 +46,7 @@ final class VideoPlayerCastController: NSObject {
 
         DispatchQueue.main.async { [weak self] in
             guard let self = self,
-                  Self.configureCastContext(receiverAppId: self.receiverAppId) else {
+                  Self.configureCastContext() else {
                 return
             }
 
@@ -170,35 +168,19 @@ final class VideoPlayerCastController: NSObject {
         return true
     }
 
-    private static func configureCastContext(receiverAppId: String?) -> Bool {
+    private static func configureCastContext() -> Bool {
         guard Thread.isMainThread else {
             return false
         }
 
         if GCKCastContext.isSharedInstanceInitialized() {
-            return configuredReceiverAppId == resolvedReceiverAppId(receiverAppId)
+            return true
         }
 
-        let appId = resolvedReceiverAppId(receiverAppId)
-
-        let criteria = GCKDiscoveryCriteria(applicationID: appId)
+        let criteria = GCKDiscoveryCriteria(applicationID: kGCKDefaultMediaReceiverApplicationID)
         let options = GCKCastOptions(discoveryCriteria: criteria)
         var error: GCKError?
-        let configured = GCKCastContext.setSharedInstanceWith(options, error: &error)
-        if configured {
-            configuredReceiverAppId = appId
-        }
-        return configured
-    }
-
-    private static var configuredReceiverAppId: String?
-
-    private static func resolvedReceiverAppId(_ receiverAppId: String?) -> String {
-        let trimmedReceiverAppId = receiverAppId?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let trimmedReceiverAppId = trimmedReceiverAppId, !trimmedReceiverAppId.isEmpty {
-            return trimmedReceiverAppId
-        }
-        return kGCKDefaultMediaReceiverApplicationID
+        return GCKCastContext.setSharedInstanceWith(options, error: &error)
     }
 
     private func addCastButton(to playerViewController: AVPlayerViewController) {
@@ -383,8 +365,7 @@ final class VideoPlayerCastController {
         return false
     }
 
-    init(receiverAppId: String?, videoUrl: String, title: String?, smallTitle: String?, artwork: String?) {
-        _ = receiverAppId
+    init(videoUrl: String, title: String?, smallTitle: String?, artwork: String?) {
         _ = videoUrl
         _ = title
         _ = smallTitle

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -16,7 +16,9 @@ final class VideoPlayerCastController: NSObject {
     private weak var player: AVPlayer?
     private weak var playerViewController: AVPlayerViewController?
     private weak var castButton: GCKUICastButton?
+    private var mediaLoadRequest: GCKRequest?
     private var isLoadedOnCast = false
+    private var isLoadingOnCast = false
     private var localWasPlaying = false
     private var isDetached = false
 
@@ -61,6 +63,7 @@ final class VideoPlayerCastController: NSObject {
             return
         }
         isDetached = true
+        clearMediaLoadRequest()
 
         DispatchQueue.main.async { [weak self] in
             guard let self = self,
@@ -78,22 +81,41 @@ final class VideoPlayerCastController: NSObject {
             self.player = nil
             self.playerViewController = nil
             self.isLoadedOnCast = false
+            self.isLoadingOnCast = false
         }
     }
 
     func play() -> Bool {
-        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
+        guard let remoteMediaClient = remoteMediaClient else {
             return false
+        }
+        guard isLoadedOnCast else {
+            return isLoadingOnCast
         }
         remoteMediaClient.play()
         return true
     }
 
     func pause() -> Bool {
-        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
+        guard let remoteMediaClient = remoteMediaClient else {
             return false
         }
+        guard isLoadedOnCast else {
+            return isLoadingOnCast
+        }
         remoteMediaClient.pause()
+        return true
+    }
+
+    func setCurrentTime(_ time: Double) -> Bool {
+        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
+            return isLoadingOnCast
+        }
+        let options = GCKMediaSeekOptions()
+        options.interval = time
+        options.relative = false
+        options.resumeState = .unchanged
+        remoteMediaClient.seek(with: options)
         return true
     }
 
@@ -112,25 +134,13 @@ final class VideoPlayerCastController: NSObject {
         return remoteMediaClient?.approximateStreamPosition() ?? 0
     }
 
-    func setCurrentTime(_ time: Double) -> Bool {
-        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
-            return false
-        }
-        let options = GCKMediaSeekOptions()
-        options.interval = time
-        options.relative = false
-        options.resumeState = .unchanged
-        remoteMediaClient.seek(with: options)
-        return true
-    }
-
     func getVolume() -> Float {
         return remoteMediaClient?.mediaStatus?.volume ?? 0
     }
 
     func setVolume(_ volume: Float) -> Bool {
         guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
-            return false
+            return isLoadingOnCast
         }
         remoteMediaClient.setStreamVolume(volume)
         return true
@@ -142,7 +152,7 @@ final class VideoPlayerCastController: NSObject {
 
     func setMuted(_ muted: Bool) -> Bool {
         guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
-            return false
+            return isLoadingOnCast
         }
         remoteMediaClient.setStreamMuted(muted)
         return true
@@ -154,7 +164,7 @@ final class VideoPlayerCastController: NSObject {
 
     func setRate(_ rate: Float) -> Bool {
         guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
-            return false
+            return isLoadingOnCast
         }
         remoteMediaClient.setPlaybackRate(rate)
         return true
@@ -166,21 +176,29 @@ final class VideoPlayerCastController: NSObject {
         }
 
         if GCKCastContext.isSharedInstanceInitialized() {
-            return true
+            return configuredReceiverAppId == resolvedReceiverAppId(receiverAppId)
         }
 
-        let trimmedReceiverAppId = receiverAppId?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let appId: String
-        if let trimmedReceiverAppId = trimmedReceiverAppId, !trimmedReceiverAppId.isEmpty {
-            appId = trimmedReceiverAppId
-        } else {
-            appId = kGCKDefaultMediaReceiverApplicationID
-        }
+        let appId = resolvedReceiverAppId(receiverAppId)
 
         let criteria = GCKDiscoveryCriteria(applicationID: appId)
         let options = GCKCastOptions(discoveryCriteria: criteria)
         var error: GCKError?
-        return GCKCastContext.setSharedInstanceWith(options, error: &error)
+        let configured = GCKCastContext.setSharedInstanceWith(options, error: &error)
+        if configured {
+            configuredReceiverAppId = appId
+        }
+        return configured
+    }
+
+    private static var configuredReceiverAppId: String?
+
+    private static func resolvedReceiverAppId(_ receiverAppId: String?) -> String {
+        let trimmedReceiverAppId = receiverAppId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedReceiverAppId = trimmedReceiverAppId, !trimmedReceiverAppId.isEmpty {
+            return trimmedReceiverAppId
+        }
+        return kGCKDefaultMediaReceiverApplicationID
     }
 
     private func addCastButton(to playerViewController: AVPlayerViewController) {
@@ -217,12 +235,17 @@ final class VideoPlayerCastController: NSObject {
         let playPosition = player?.currentTime().seconds ?? 0
         localWasPlaying = (player?.rate ?? 0) > 0
         player?.pause()
+        isLoadedOnCast = false
+        isLoadingOnCast = true
+        clearMediaLoadRequest()
+
         let mediaLoadRequestDataBuilder = GCKMediaLoadRequestDataBuilder()
         mediaLoadRequestDataBuilder.mediaInformation = mediaInfo
         mediaLoadRequestDataBuilder.autoplay = NSNumber(value: localWasPlaying)
         mediaLoadRequestDataBuilder.startTime = playPosition.isFinite ? playPosition : 0
-        remoteMediaClient.loadMedia(with: mediaLoadRequestDataBuilder.build())
-        isLoadedOnCast = true
+        let request = remoteMediaClient.loadMedia(with: mediaLoadRequestDataBuilder.build())
+        request.delegate = self
+        mediaLoadRequest = request
     }
 
     private func makeMediaInformation() -> GCKMediaInformation? {
@@ -290,6 +313,32 @@ final class VideoPlayerCastController: NSObject {
             }
         }
     }
+
+    private func clearMediaLoadRequest() {
+        mediaLoadRequest?.delegate = nil
+        mediaLoadRequest = nil
+    }
+
+    private func completeMediaLoadRequest(_ request: GCKRequest) {
+        guard request === mediaLoadRequest else {
+            return
+        }
+        clearMediaLoadRequest()
+        isLoadingOnCast = false
+        isLoadedOnCast = true
+    }
+
+    private func failMediaLoadRequest(_ request: GCKRequest) {
+        guard request === mediaLoadRequest else {
+            return
+        }
+        clearMediaLoadRequest()
+        isLoadingOnCast = false
+        isLoadedOnCast = false
+        if localWasPlaying {
+            player?.play()
+        }
+    }
 }
 
 extension VideoPlayerCastController: GCKSessionManagerListener {
@@ -310,6 +359,20 @@ extension VideoPlayerCastController: GCKSessionManagerListener {
         if localWasPlaying {
             player?.play()
         }
+    }
+}
+
+extension VideoPlayerCastController: GCKRequestDelegate {
+    @objc func requestDidComplete(_ request: GCKRequest) {
+        completeMediaLoadRequest(request)
+    }
+
+    @objc func request(_ request: GCKRequest, didFailWithError error: GCKError) {
+        failMediaLoadRequest(request)
+    }
+
+    @objc func request(_ request: GCKRequest, didAbortWith abortReason: GCKRequestAbortReason) {
+        failMediaLoadRequest(request)
     }
 }
 

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -313,15 +313,18 @@ private extension VideoPlayerCastController {
         }
     }
 
-    func applyPendingCastCommandsToLocalPlayer() {
+    func applyPendingCastCommandsToLocalPlayer() -> Bool {
+        var didApplyPlaybackCommand = false
         let commands = pendingCastCommands
         pendingCastCommands.removeAll()
         for command in commands {
             switch command {
             case .play:
                 player?.play()
+                didApplyPlaybackCommand = true
             case .pause:
                 player?.pause()
+                didApplyPlaybackCommand = true
             case .seek(let time):
                 player?.seek(to: CMTime(seconds: time, preferredTimescale: 600))
             case .volume(let volume):
@@ -330,8 +333,10 @@ private extension VideoPlayerCastController {
                 player?.isMuted = muted
             case .rate(let rate):
                 player?.rate = rate
+                didApplyPlaybackCommand = true
             }
         }
+        return didApplyPlaybackCommand
     }
 
     func makeMediaInformation() -> GCKMediaInformation? {
@@ -430,7 +435,10 @@ private extension VideoPlayerCastController {
         isLoadingOnCast = false
         isLoadedOnCast = false
         if !pendingCastCommands.isEmpty {
-            applyPendingCastCommandsToLocalPlayer()
+            let didApplyPlaybackCommand = applyPendingCastCommandsToLocalPlayer()
+            if localWasPlaying && !didApplyPlaybackCommand {
+                player?.play()
+            }
             return
         }
         if localWasPlaying {

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -24,8 +24,6 @@ final class VideoPlayerCastController: NSObject {
     private weak var player: AVPlayer?
     private weak var playerViewController: AVPlayerViewController?
     private weak var castButton: GCKUICastButton?
-    private var castOverlayViewController: UIViewController?
-    private var didCreateCastOverlayViewController = false
     private var mediaLoadRequest: GCKRequest?
     private var pendingCastCommands: [PendingCastCommand] = []
     private var isLoadedOnCast = false
@@ -95,11 +93,6 @@ final class VideoPlayerCastController: NSObject {
             GCKCastContext.sharedInstance().sessionManager.remove(self)
             self.castButton?.removeFromSuperview()
             self.castButton = nil
-            if self.didCreateCastOverlayViewController {
-                self.playerViewController?.customOverlayViewController = nil
-            }
-            self.castOverlayViewController = nil
-            self.didCreateCastOverlayViewController = false
             self.player = nil
             self.playerViewController = nil
             self.isLoadedOnCast = false
@@ -227,22 +220,7 @@ private extension VideoPlayerCastController {
             return
         }
 
-        let overlayViewController: UIViewController
-        if let currentOverlayViewController = playerViewController.customOverlayViewController {
-            overlayViewController = currentOverlayViewController
-        } else {
-            overlayViewController = UIViewController()
-            overlayViewController.view.backgroundColor = .clear
-            overlayViewController.view.isUserInteractionEnabled = true
-            playerViewController.customOverlayViewController = overlayViewController
-            castOverlayViewController = overlayViewController
-            didCreateCastOverlayViewController = true
-        }
-
-        guard let overlayView = overlayViewController.view else {
-            return
-        }
-
+        let overlayView = playerViewController.view
         overlayView.isUserInteractionEnabled = true
         let button = GCKUICastButton(frame: .zero)
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -1,0 +1,366 @@
+import AVFoundation
+import AVKit
+import Foundation
+import UIKit
+
+#if canImport(GoogleCast)
+import GoogleCast
+
+final class VideoPlayerCastController: NSObject {
+    private let receiverAppId: String?
+    private let videoUrl: String
+    private let title: String?
+    private let smallTitle: String?
+    private let artwork: String?
+
+    private weak var player: AVPlayer?
+    private weak var playerViewController: AVPlayerViewController?
+    private weak var castButton: GCKUICastButton?
+    private var isLoadedOnCast = false
+    private var localWasPlaying = false
+    private var isDetached = false
+
+    var isCasting: Bool {
+        return remoteMediaClient != nil && isLoadedOnCast
+    }
+
+    private var remoteMediaClient: GCKRemoteMediaClient? {
+        guard GCKCastContext.isSharedInstanceInitialized() else {
+            return nil
+        }
+        return GCKCastContext.sharedInstance().sessionManager.currentCastSession?.remoteMediaClient
+    }
+
+    init(receiverAppId: String?, videoUrl: String, title: String?, smallTitle: String?, artwork: String?) {
+        self.receiverAppId = receiverAppId
+        self.videoUrl = videoUrl
+        self.title = title
+        self.smallTitle = smallTitle
+        self.artwork = artwork
+        super.init()
+    }
+
+    func attach(to playerViewController: AVPlayerViewController, player: AVPlayer) {
+        self.playerViewController = playerViewController
+        self.player = player
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                  Self.configureCastContext(receiverAppId: self.receiverAppId) else {
+                return
+            }
+
+            GCKCastContext.sharedInstance().sessionManager.add(self)
+            self.addCastButton(to: playerViewController)
+            self.loadMediaIfCastSessionAvailable()
+        }
+    }
+
+    func detach(stopRemoteMedia: Bool) {
+        guard !isDetached else {
+            return
+        }
+        isDetached = true
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                  GCKCastContext.isSharedInstanceInitialized() else {
+                return
+            }
+
+            if stopRemoteMedia {
+                self.remoteMediaClient?.stop()
+            }
+
+            GCKCastContext.sharedInstance().sessionManager.remove(self)
+            self.castButton?.removeFromSuperview()
+            self.castButton = nil
+            self.player = nil
+            self.playerViewController = nil
+            self.isLoadedOnCast = false
+        }
+    }
+
+    func play() -> Bool {
+        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
+            return false
+        }
+        remoteMediaClient.play()
+        return true
+    }
+
+    func pause() -> Bool {
+        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
+            return false
+        }
+        remoteMediaClient.pause()
+        return true
+    }
+
+    func isPlaying() -> Bool {
+        guard let playerState = remoteMediaClient?.mediaStatus?.playerState else {
+            return false
+        }
+        return playerState == .playing || playerState == .buffering
+    }
+
+    func getDuration() -> Double {
+        return remoteMediaClient?.mediaStatus?.mediaInformation?.streamDuration ?? 0
+    }
+
+    func getCurrentTime() -> Double {
+        return remoteMediaClient?.approximateStreamPosition() ?? 0
+    }
+
+    func setCurrentTime(_ time: Double) -> Bool {
+        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
+            return false
+        }
+        let options = GCKMediaSeekOptions()
+        options.interval = time
+        options.relative = false
+        options.resumeState = .unchanged
+        remoteMediaClient.seek(with: options)
+        return true
+    }
+
+    func getVolume() -> Float {
+        return remoteMediaClient?.mediaStatus?.volume ?? 0
+    }
+
+    func setVolume(_ volume: Float) -> Bool {
+        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
+            return false
+        }
+        remoteMediaClient.setStreamVolume(volume)
+        return true
+    }
+
+    func getMuted() -> Bool {
+        return remoteMediaClient?.mediaStatus?.isMuted ?? false
+    }
+
+    func setMuted(_ muted: Bool) -> Bool {
+        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
+            return false
+        }
+        remoteMediaClient.setStreamMuted(muted)
+        return true
+    }
+
+    func getRate() -> Float {
+        return remoteMediaClient?.mediaStatus?.playbackRate ?? 0
+    }
+
+    func setRate(_ rate: Float) -> Bool {
+        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
+            return false
+        }
+        remoteMediaClient.setPlaybackRate(rate)
+        return true
+    }
+
+    private static func configureCastContext(receiverAppId: String?) -> Bool {
+        guard Thread.isMainThread else {
+            return false
+        }
+
+        if GCKCastContext.isSharedInstanceInitialized() {
+            return true
+        }
+
+        let trimmedReceiverAppId = receiverAppId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let appId: String
+        if let trimmedReceiverAppId = trimmedReceiverAppId, !trimmedReceiverAppId.isEmpty {
+            appId = trimmedReceiverAppId
+        } else {
+            appId = kGCKDefaultMediaReceiverApplicationID
+        }
+
+        let criteria = GCKDiscoveryCriteria(applicationID: appId)
+        let options = GCKCastOptions(discoveryCriteria: criteria)
+        var error: GCKError?
+        return GCKCastContext.setSharedInstanceWith(options, error: &error)
+    }
+
+    private func addCastButton(to playerViewController: AVPlayerViewController) {
+        guard castButton == nil,
+              let overlayView = playerViewController.contentOverlayView else {
+            return
+        }
+
+        let button = GCKUICastButton(frame: .zero)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.tintColor = .white
+        button.backgroundColor = UIColor.black.withAlphaComponent(0.35)
+        button.layer.cornerRadius = 22
+        button.clipsToBounds = true
+        button.accessibilityLabel = "Cast"
+
+        overlayView.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.widthAnchor.constraint(equalToConstant: 44),
+            button.heightAnchor.constraint(equalToConstant: 44),
+            button.topAnchor.constraint(equalTo: overlayView.safeAreaLayoutGuide.topAnchor, constant: 16),
+            button.trailingAnchor.constraint(equalTo: overlayView.safeAreaLayoutGuide.trailingAnchor, constant: -16)
+        ])
+
+        castButton = button
+    }
+
+    private func loadMediaIfCastSessionAvailable() {
+        guard let remoteMediaClient = remoteMediaClient,
+              let mediaInfo = makeMediaInformation() else {
+            return
+        }
+
+        let playPosition = player?.currentTime().seconds ?? 0
+        localWasPlaying = (player?.rate ?? 0) > 0
+        player?.pause()
+        let mediaLoadRequestDataBuilder = GCKMediaLoadRequestDataBuilder()
+        mediaLoadRequestDataBuilder.mediaInformation = mediaInfo
+        mediaLoadRequestDataBuilder.autoplay = NSNumber(value: localWasPlaying)
+        mediaLoadRequestDataBuilder.startTime = playPosition.isFinite ? playPosition : 0
+        remoteMediaClient.loadMedia(with: mediaLoadRequestDataBuilder.build())
+        isLoadedOnCast = true
+    }
+
+    private func makeMediaInformation() -> GCKMediaInformation? {
+        guard let url = URL(string: videoUrl) else {
+            return nil
+        }
+
+        let metadata = GCKMediaMetadata()
+        metadata.setString(title ?? url.lastPathComponent, forKey: kGCKMetadataKeyTitle)
+        if let smallTitle = smallTitle, !smallTitle.isEmpty {
+            metadata.setString(smallTitle, forKey: kGCKMetadataKeySubtitle)
+        }
+        if let artwork = artwork,
+           let artworkUrl = URL(string: artwork) {
+            metadata.addImage(GCKImage(url: artworkUrl, width: 480, height: 360))
+        }
+
+        let builder = GCKMediaInformationBuilder(contentURL: url)
+        builder.streamType = .buffered
+        builder.contentType = contentType(for: url)
+        builder.metadata = metadata
+        if let duration = player?.currentItem?.duration.seconds,
+           duration.isFinite,
+           duration > 0 {
+            builder.streamDuration = duration
+        }
+        return builder.build()
+    }
+
+    private func contentType(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "m3u8":
+            return "application/x-mpegURL"
+        case "mpd":
+            return "application/dash+xml"
+        case "mov":
+            return "video/quicktime"
+        case "m4v":
+            return "video/x-m4v"
+        case "webm":
+            return "video/webm"
+        case "mp4":
+            return "video/mp4"
+        default:
+            return "video/mp4"
+        }
+    }
+
+    private func resumeLocalPlayback(from session: GCKSession) {
+        guard !isDetached,
+              isLoadedOnCast else {
+            return
+        }
+
+        let remoteMediaClient = session.remoteMediaClient
+        let position = remoteMediaClient?.approximateStreamPosition() ?? 0
+        let shouldResume = remoteMediaClient?.mediaStatus?.playerState == .playing ||
+            remoteMediaClient?.mediaStatus?.playerState == .buffering
+
+        isLoadedOnCast = false
+        let seekTime = CMTime(seconds: position, preferredTimescale: 600)
+        player?.seek(to: seekTime) { [weak self] _ in
+            if shouldResume || self?.localWasPlaying == true {
+                self?.player?.play()
+            }
+        }
+    }
+}
+
+extension VideoPlayerCastController: GCKSessionManagerListener {
+    @objc func sessionManager(_ sessionManager: GCKSessionManager, didStart session: GCKSession) {
+        loadMediaIfCastSessionAvailable()
+    }
+
+    @objc func sessionManager(_ sessionManager: GCKSessionManager, didResumeSession session: GCKSession) {
+        loadMediaIfCastSessionAvailable()
+    }
+
+    @objc func sessionManager(_ sessionManager: GCKSessionManager, didEnd session: GCKSession, withError error: Error?) {
+        resumeLocalPlayback(from: session)
+    }
+
+    @objc func sessionManager(_ sessionManager: GCKSessionManager, didFailToStart session: GCKSession, withError error: Error) {
+        isLoadedOnCast = false
+        if localWasPlaying {
+            player?.play()
+        }
+    }
+}
+
+#else
+
+final class VideoPlayerCastController {
+    var isCasting: Bool {
+        return false
+    }
+
+    init(receiverAppId: String?, videoUrl: String, title: String?, smallTitle: String?, artwork: String?) {
+        _ = receiverAppId
+        _ = videoUrl
+        _ = title
+        _ = smallTitle
+        _ = artwork
+    }
+
+    func attach(to playerViewController: AVPlayerViewController, player: AVPlayer) {
+        _ = playerViewController
+        _ = player
+    }
+
+    func detach(stopRemoteMedia: Bool) {
+        _ = stopRemoteMedia
+    }
+
+    func play() -> Bool { return false }
+    func pause() -> Bool { return false }
+    func isPlaying() -> Bool { return false }
+    func getDuration() -> Double { return 0 }
+    func getCurrentTime() -> Double { return 0 }
+    func setCurrentTime(_ time: Double) -> Bool {
+        _ = time
+        return false
+    }
+    func getVolume() -> Float { return 0 }
+    func setVolume(_ volume: Float) -> Bool {
+        _ = volume
+        return false
+    }
+    func getMuted() -> Bool { return false }
+    func setMuted(_ muted: Bool) -> Bool {
+        _ = muted
+        return false
+    }
+    func getRate() -> Float { return 0 }
+    func setRate(_ rate: Float) -> Bool {
+        _ = rate
+        return false
+    }
+}
+
+#endif

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -24,12 +24,18 @@ final class VideoPlayerCastController: NSObject {
     private weak var player: AVPlayer?
     private weak var playerViewController: AVPlayerViewController?
     private weak var castButton: GCKUICastButton?
+    private weak var observedRemoteMediaClient: GCKRemoteMediaClient?
     private var mediaLoadRequest: GCKRequest?
     private var pendingCastCommands: [PendingCastCommand] = []
     private var isLoadedOnCast = false
     private var isLoadingOnCast = false
     private var localWasPlaying = false
     private var isDetached = false
+    private var lastRemoteIsPlaying: Bool?
+    private var didNotifyRemoteEnd = false
+    private var onPlay: (() -> Void)?
+    private var onPause: (() -> Void)?
+    private var onEnd: (() -> Void)?
 
     var isCasting: Bool {
         return remoteMediaClient != nil && isLoadedOnCast
@@ -90,6 +96,7 @@ final class VideoPlayerCastController: NSObject {
                 self.remoteMediaClient?.stop()
             }
 
+            self.stopRemoteMediaObservation()
             GCKCastContext.sharedInstance().sessionManager.remove(self)
             self.castButton?.removeFromSuperview()
             self.castButton = nil
@@ -196,6 +203,39 @@ final class VideoPlayerCastController: NSObject {
         remoteMediaClient.setPlaybackRate(rate)
         return true
     }
+
+    func restartPlayback() -> Bool {
+        guard let remoteMediaClient = remoteMediaClient,
+              let mediaInfo = makeMediaInformation() else {
+            return false
+        }
+
+        didNotifyRemoteEnd = false
+        isLoadedOnCast = false
+        isLoadingOnCast = true
+        clearMediaLoadRequest()
+
+        let mediaLoadRequestDataBuilder = GCKMediaLoadRequestDataBuilder()
+        mediaLoadRequestDataBuilder.mediaInformation = mediaInfo
+        mediaLoadRequestDataBuilder.autoplay = NSNumber(value: true)
+        mediaLoadRequestDataBuilder.startTime = 0
+        let request = remoteMediaClient.loadMedia(with: mediaLoadRequestDataBuilder.build())
+        request.delegate = self
+        mediaLoadRequest = request
+        return true
+    }
+
+    func setOnPlay(_ callback: @escaping () -> Void) {
+        onPlay = callback
+    }
+
+    func setOnPause(_ callback: @escaping () -> Void) {
+        onPause = callback
+    }
+
+    func setOnEnd(_ callback: @escaping () -> Void) {
+        onEnd = callback
+    }
 }
 
 private extension VideoPlayerCastController {
@@ -250,11 +290,14 @@ private extension VideoPlayerCastController {
             return
         }
 
+        observeRemoteMediaClient(remoteMediaClient)
         let playPosition = player?.currentTime().seconds ?? 0
         localWasPlaying = (player?.rate ?? 0) > 0
         player?.pause()
         isLoadedOnCast = false
         isLoadingOnCast = true
+        lastRemoteIsPlaying = nil
+        didNotifyRemoteEnd = false
         clearMediaLoadRequest()
 
         let mediaLoadRequestDataBuilder = GCKMediaLoadRequestDataBuilder()
@@ -264,6 +307,23 @@ private extension VideoPlayerCastController {
         let request = remoteMediaClient.loadMedia(with: mediaLoadRequestDataBuilder.build())
         request.delegate = self
         mediaLoadRequest = request
+    }
+
+    func observeRemoteMediaClient(_ remoteMediaClient: GCKRemoteMediaClient) {
+        if let observedRemoteMediaClient = observedRemoteMediaClient,
+           observedRemoteMediaClient === remoteMediaClient {
+            return
+        }
+
+        observedRemoteMediaClient?.remove(self)
+        remoteMediaClient.add(self)
+        observedRemoteMediaClient = remoteMediaClient
+    }
+
+    func stopRemoteMediaObservation() {
+        observedRemoteMediaClient?.remove(self)
+        observedRemoteMediaClient = nil
+        lastRemoteIsPlaying = nil
     }
 
     private func enqueuePendingCastCommand(_ command: PendingCastCommand) -> Bool {
@@ -398,6 +458,7 @@ private extension VideoPlayerCastController {
 
         isLoadedOnCast = false
         isLoadingOnCast = false
+        stopRemoteMediaObservation()
         clearMediaLoadRequest()
         pendingCastCommands.removeAll()
         let seekTime = CMTime(seconds: position, preferredTimescale: 600)
@@ -420,6 +481,7 @@ private extension VideoPlayerCastController {
         clearMediaLoadRequest()
         isLoadingOnCast = false
         isLoadedOnCast = true
+        didNotifyRemoteEnd = false
         flushPendingCastCommands()
     }
 
@@ -445,6 +507,43 @@ private extension VideoPlayerCastController {
             player?.play()
         } else if resumeLocalIfNeeded {
             player?.pause()
+        }
+    }
+
+    func handleRemoteMediaStatus(_ mediaStatus: GCKMediaStatus?) {
+        guard !isDetached,
+              isLoadedOnCast || isLoadingOnCast,
+              let mediaStatus = mediaStatus else {
+            return
+        }
+
+        switch mediaStatus.playerState {
+        case .playing, .buffering:
+            didNotifyRemoteEnd = false
+            if lastRemoteIsPlaying != true {
+                DispatchQueue.main.async { [weak self] in
+                    self?.onPlay?()
+                }
+            }
+            lastRemoteIsPlaying = true
+        case .paused:
+            if lastRemoteIsPlaying == true {
+                DispatchQueue.main.async { [weak self] in
+                    self?.onPause?()
+                }
+            }
+            lastRemoteIsPlaying = false
+        case .idle:
+            if mediaStatus.idleReason == .finished,
+               !didNotifyRemoteEnd {
+                didNotifyRemoteEnd = true
+                DispatchQueue.main.async { [weak self] in
+                    self?.onEnd?()
+                }
+            }
+            lastRemoteIsPlaying = false
+        default:
+            break
         }
     }
 }
@@ -482,6 +581,13 @@ extension VideoPlayerCastController: GCKRequestDelegate {
 
     @objc func request(_ request: GCKRequest, didAbortWith abortReason: GCKRequestAbortReason) {
         failMediaLoadRequest(request)
+    }
+}
+
+extension VideoPlayerCastController: GCKRemoteMediaClientListener {
+    @objc(remoteMediaClient:didUpdateMediaStatus:)
+    func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
+        handleRemoteMediaStatus(mediaStatus)
     }
 }
 
@@ -531,6 +637,16 @@ final class VideoPlayerCastController {
     func setRate(_ rate: Float) -> Bool {
         _ = rate
         return false
+    }
+    func restartPlayback() -> Bool { return false }
+    func setOnPlay(_ callback: @escaping () -> Void) {
+        _ = callback
+    }
+    func setOnPause(_ callback: @escaping () -> Void) {
+        _ = callback
+    }
+    func setOnEnd(_ callback: @escaping () -> Void) {
+        _ = callback
     }
 }
 

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -285,7 +285,7 @@ private extension VideoPlayerCastController {
         mediaLoadRequest = request
     }
 
-    func enqueuePendingCastCommand(_ command: PendingCastCommand) -> Bool {
+    private func enqueuePendingCastCommand(_ command: PendingCastCommand) -> Bool {
         guard isLoadingOnCast else {
             return false
         }
@@ -311,7 +311,7 @@ private extension VideoPlayerCastController {
         }
     }
 
-    func apply(_ command: PendingCastCommand, to remoteMediaClient: GCKRemoteMediaClient) {
+    private func apply(_ command: PendingCastCommand, to remoteMediaClient: GCKRemoteMediaClient) {
         switch command {
         case .play:
             remoteMediaClient.play()

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -7,6 +7,15 @@ import UIKit
 import GoogleCast
 
 final class VideoPlayerCastController: NSObject {
+    private enum PendingCastCommand {
+        case play
+        case pause
+        case seek(Double)
+        case volume(Float)
+        case muted(Bool)
+        case rate(Float)
+    }
+
     private let videoUrl: String
     private let title: String?
     private let smallTitle: String?
@@ -15,7 +24,10 @@ final class VideoPlayerCastController: NSObject {
     private weak var player: AVPlayer?
     private weak var playerViewController: AVPlayerViewController?
     private weak var castButton: GCKUICastButton?
+    private var castOverlayViewController: UIViewController?
+    private var didCreateCastOverlayViewController = false
     private var mediaLoadRequest: GCKRequest?
+    private var pendingCastCommands: [PendingCastCommand] = []
     private var isLoadedOnCast = false
     private var isLoadingOnCast = false
     private var localWasPlaying = false
@@ -44,7 +56,7 @@ final class VideoPlayerCastController: NSObject {
         self.playerViewController = playerViewController
         self.player = player
 
-        DispatchQueue.main.async { [weak self] in
+        let attachOnMain = { [weak self] in
             guard let self = self,
                   Self.configureCastContext() else {
                 return
@@ -54,6 +66,12 @@ final class VideoPlayerCastController: NSObject {
             self.addCastButton(to: playerViewController)
             self.loadMediaIfCastSessionAvailable()
         }
+
+        if Thread.isMainThread {
+            attachOnMain()
+        } else {
+            DispatchQueue.main.async(execute: attachOnMain)
+        }
     }
 
     func detach(stopRemoteMedia: Bool) {
@@ -62,6 +80,7 @@ final class VideoPlayerCastController: NSObject {
         }
         isDetached = true
         clearMediaLoadRequest()
+        pendingCastCommands.removeAll()
 
         DispatchQueue.main.async { [weak self] in
             guard let self = self,
@@ -76,6 +95,11 @@ final class VideoPlayerCastController: NSObject {
             GCKCastContext.sharedInstance().sessionManager.remove(self)
             self.castButton?.removeFromSuperview()
             self.castButton = nil
+            if self.didCreateCastOverlayViewController {
+                self.playerViewController?.customOverlayViewController = nil
+            }
+            self.castOverlayViewController = nil
+            self.didCreateCastOverlayViewController = false
             self.player = nil
             self.playerViewController = nil
             self.isLoadedOnCast = false
@@ -88,7 +112,7 @@ final class VideoPlayerCastController: NSObject {
             return false
         }
         guard isLoadedOnCast else {
-            return isLoadingOnCast
+            return enqueuePendingCastCommand(.play)
         }
         remoteMediaClient.play()
         return true
@@ -99,15 +123,18 @@ final class VideoPlayerCastController: NSObject {
             return false
         }
         guard isLoadedOnCast else {
-            return isLoadingOnCast
+            return enqueuePendingCastCommand(.pause)
         }
         remoteMediaClient.pause()
         return true
     }
 
     func setCurrentTime(_ time: Double) -> Bool {
-        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
-            return isLoadingOnCast
+        guard let remoteMediaClient = remoteMediaClient else {
+            return false
+        }
+        guard isLoadedOnCast else {
+            return enqueuePendingCastCommand(.seek(time))
         }
         let options = GCKMediaSeekOptions()
         options.interval = time
@@ -137,8 +164,11 @@ final class VideoPlayerCastController: NSObject {
     }
 
     func setVolume(_ volume: Float) -> Bool {
-        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
-            return isLoadingOnCast
+        guard let remoteMediaClient = remoteMediaClient else {
+            return false
+        }
+        guard isLoadedOnCast else {
+            return enqueuePendingCastCommand(.volume(volume))
         }
         remoteMediaClient.setStreamVolume(volume)
         return true
@@ -149,8 +179,11 @@ final class VideoPlayerCastController: NSObject {
     }
 
     func setMuted(_ muted: Bool) -> Bool {
-        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
-            return isLoadingOnCast
+        guard let remoteMediaClient = remoteMediaClient else {
+            return false
+        }
+        guard isLoadedOnCast else {
+            return enqueuePendingCastCommand(.muted(muted))
         }
         remoteMediaClient.setStreamMuted(muted)
         return true
@@ -161,14 +194,19 @@ final class VideoPlayerCastController: NSObject {
     }
 
     func setRate(_ rate: Float) -> Bool {
-        guard let remoteMediaClient = remoteMediaClient, isLoadedOnCast else {
-            return isLoadingOnCast
+        guard let remoteMediaClient = remoteMediaClient else {
+            return false
+        }
+        guard isLoadedOnCast else {
+            return enqueuePendingCastCommand(.rate(rate))
         }
         remoteMediaClient.setPlaybackRate(rate)
         return true
     }
+}
 
-    private static func configureCastContext() -> Bool {
+private extension VideoPlayerCastController {
+    static func configureCastContext() -> Bool {
         guard Thread.isMainThread else {
             return false
         }
@@ -177,18 +215,35 @@ final class VideoPlayerCastController: NSObject {
             return true
         }
 
+        // This plugin intentionally uses the default media receiver.
         let criteria = GCKDiscoveryCriteria(applicationID: kGCKDefaultMediaReceiverApplicationID)
         let options = GCKCastOptions(discoveryCriteria: criteria)
         var error: GCKError?
         return GCKCastContext.setSharedInstanceWith(options, error: &error)
     }
 
-    private func addCastButton(to playerViewController: AVPlayerViewController) {
-        guard castButton == nil,
-              let overlayView = playerViewController.contentOverlayView else {
+    func addCastButton(to playerViewController: AVPlayerViewController) {
+        guard castButton == nil else {
             return
         }
 
+        let overlayViewController: UIViewController
+        if let currentOverlayViewController = playerViewController.customOverlayViewController {
+            overlayViewController = currentOverlayViewController
+        } else {
+            overlayViewController = UIViewController()
+            overlayViewController.view.backgroundColor = .clear
+            overlayViewController.view.isUserInteractionEnabled = true
+            playerViewController.customOverlayViewController = overlayViewController
+            castOverlayViewController = overlayViewController
+            didCreateCastOverlayViewController = true
+        }
+
+        guard let overlayView = overlayViewController.view else {
+            return
+        }
+
+        overlayView.isUserInteractionEnabled = true
         let button = GCKUICastButton(frame: .zero)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.tintColor = .white
@@ -208,7 +263,7 @@ final class VideoPlayerCastController: NSObject {
         castButton = button
     }
 
-    private func loadMediaIfCastSessionAvailable() {
+    func loadMediaIfCastSessionAvailable() {
         guard let remoteMediaClient = remoteMediaClient,
               let mediaInfo = makeMediaInformation() else {
             return
@@ -230,7 +285,75 @@ final class VideoPlayerCastController: NSObject {
         mediaLoadRequest = request
     }
 
-    private func makeMediaInformation() -> GCKMediaInformation? {
+    func enqueuePendingCastCommand(_ command: PendingCastCommand) -> Bool {
+        guard isLoadingOnCast else {
+            return false
+        }
+
+        pendingCastCommands.append(command)
+        if pendingCastCommands.count > 20 {
+            pendingCastCommands.removeFirst(pendingCastCommands.count - 20)
+        }
+        return true
+    }
+
+    func flushPendingCastCommands() {
+        guard let remoteMediaClient = remoteMediaClient,
+              isLoadedOnCast else {
+            pendingCastCommands.removeAll()
+            return
+        }
+
+        let commands = pendingCastCommands
+        pendingCastCommands.removeAll()
+        for command in commands {
+            apply(command, to: remoteMediaClient)
+        }
+    }
+
+    func apply(_ command: PendingCastCommand, to remoteMediaClient: GCKRemoteMediaClient) {
+        switch command {
+        case .play:
+            remoteMediaClient.play()
+        case .pause:
+            remoteMediaClient.pause()
+        case .seek(let time):
+            let options = GCKMediaSeekOptions()
+            options.interval = time
+            options.relative = false
+            options.resumeState = .unchanged
+            remoteMediaClient.seek(with: options)
+        case .volume(let volume):
+            remoteMediaClient.setStreamVolume(volume)
+        case .muted(let muted):
+            remoteMediaClient.setStreamMuted(muted)
+        case .rate(let rate):
+            remoteMediaClient.setPlaybackRate(rate)
+        }
+    }
+
+    func applyPendingCastCommandsToLocalPlayer() {
+        let commands = pendingCastCommands
+        pendingCastCommands.removeAll()
+        for command in commands {
+            switch command {
+            case .play:
+                player?.play()
+            case .pause:
+                player?.pause()
+            case .seek(let time):
+                player?.seek(to: CMTime(seconds: time, preferredTimescale: 600))
+            case .volume(let volume):
+                player?.volume = volume
+            case .muted(let muted):
+                player?.isMuted = muted
+            case .rate(let rate):
+                player?.rate = rate
+            }
+        }
+    }
+
+    func makeMediaInformation() -> GCKMediaInformation? {
         guard let url = URL(string: videoUrl) else {
             return nil
         }
@@ -257,7 +380,7 @@ final class VideoPlayerCastController: NSObject {
         return builder.build()
     }
 
-    private func contentType(for url: URL) -> String {
+    func contentType(for url: URL) -> String {
         switch url.pathExtension.lowercased() {
         case "m3u8":
             return "application/x-mpegURL"
@@ -276,7 +399,7 @@ final class VideoPlayerCastController: NSObject {
         }
     }
 
-    private func resumeLocalPlayback(from session: GCKSession) {
+    func resumeLocalPlayback(from session: GCKSession) {
         guard !isDetached,
               isLoadedOnCast else {
             return
@@ -288,37 +411,51 @@ final class VideoPlayerCastController: NSObject {
             remoteMediaClient?.mediaStatus?.playerState == .buffering
 
         isLoadedOnCast = false
+        isLoadingOnCast = false
+        clearMediaLoadRequest()
+        pendingCastCommands.removeAll()
         let seekTime = CMTime(seconds: position, preferredTimescale: 600)
         player?.seek(to: seekTime) { [weak self] _ in
-            if shouldResume || self?.localWasPlaying == true {
+            if shouldResume {
                 self?.player?.play()
             }
         }
     }
 
-    private func clearMediaLoadRequest() {
+    func clearMediaLoadRequest() {
         mediaLoadRequest?.delegate = nil
         mediaLoadRequest = nil
     }
 
-    private func completeMediaLoadRequest(_ request: GCKRequest) {
+    func completeMediaLoadRequest(_ request: GCKRequest) {
         guard request === mediaLoadRequest else {
             return
         }
         clearMediaLoadRequest()
         isLoadingOnCast = false
         isLoadedOnCast = true
+        flushPendingCastCommands()
     }
 
-    private func failMediaLoadRequest(_ request: GCKRequest) {
+    func failMediaLoadRequest(_ request: GCKRequest) {
         guard request === mediaLoadRequest else {
             return
         }
+        cancelPendingCastHandoff(resumeLocalIfNeeded: true)
+    }
+
+    func cancelPendingCastHandoff(resumeLocalIfNeeded: Bool) {
         clearMediaLoadRequest()
         isLoadingOnCast = false
         isLoadedOnCast = false
+        if !pendingCastCommands.isEmpty {
+            applyPendingCastCommandsToLocalPlayer()
+            return
+        }
         if localWasPlaying {
             player?.play()
+        } else if resumeLocalIfNeeded {
+            player?.pause()
         }
     }
 }
@@ -333,14 +470,15 @@ extension VideoPlayerCastController: GCKSessionManagerListener {
     }
 
     @objc func sessionManager(_ sessionManager: GCKSessionManager, didEnd session: GCKSession, withError error: Error?) {
-        resumeLocalPlayback(from: session)
+        if isLoadedOnCast {
+            resumeLocalPlayback(from: session)
+        } else if isLoadingOnCast {
+            cancelPendingCastHandoff(resumeLocalIfNeeded: true)
+        }
     }
 
     @objc func sessionManager(_ sessionManager: GCKSessionManager, didFailToStart session: GCKSession, withError error: Error) {
-        isLoadedOnCast = false
-        if localWasPlaying {
-            player?.play()
-        }
+        cancelPendingCastHandoff(resumeLocalIfNeeded: true)
     }
 }
 

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -309,6 +309,22 @@ private extension VideoPlayerCastController {
         mediaLoadRequest = request
     }
 
+    func resumeCastSession(_ session: GCKSession) {
+        clearMediaLoadRequest()
+        pendingCastCommands.removeAll()
+        isLoadingOnCast = false
+
+        guard let remoteMediaClient = session.remoteMediaClient else {
+            isLoadedOnCast = false
+            stopRemoteMediaObservation()
+            return
+        }
+
+        observeRemoteMediaClient(remoteMediaClient)
+        isLoadedOnCast = isCurrentVideo(remoteMediaClient.mediaStatus?.mediaInformation)
+        handleRemoteMediaStatus(remoteMediaClient.mediaStatus)
+    }
+
     func observeRemoteMediaClient(_ remoteMediaClient: GCKRemoteMediaClient) {
         if let observedRemoteMediaClient = observedRemoteMediaClient,
            observedRemoteMediaClient === remoteMediaClient {
@@ -426,6 +442,19 @@ private extension VideoPlayerCastController {
         return builder.build()
     }
 
+    func isCurrentVideo(_ mediaInformation: GCKMediaInformation?) -> Bool {
+        guard let mediaInformation = mediaInformation else {
+            return false
+        }
+        if mediaInformation.contentID == videoUrl {
+            return true
+        }
+        guard let expectedUrl = URL(string: videoUrl) else {
+            return false
+        }
+        return mediaInformation.contentURL == expectedUrl
+    }
+
     func contentType(for url: URL) -> String {
         switch url.pathExtension.lowercased() {
         case "m3u8":
@@ -510,10 +539,21 @@ private extension VideoPlayerCastController {
         }
     }
 
+    func shouldHandleRemoteMediaStatus(_ mediaStatus: GCKMediaStatus) -> Bool {
+        if isLoadedOnCast || isLoadingOnCast {
+            return true
+        }
+        guard isCurrentVideo(mediaStatus.mediaInformation) else {
+            return false
+        }
+        isLoadedOnCast = true
+        return true
+    }
+
     func handleRemoteMediaStatus(_ mediaStatus: GCKMediaStatus?) {
         guard !isDetached,
-              isLoadedOnCast || isLoadingOnCast,
-              let mediaStatus = mediaStatus else {
+              let mediaStatus = mediaStatus,
+              shouldHandleRemoteMediaStatus(mediaStatus) else {
             return
         }
 
@@ -554,7 +594,7 @@ extension VideoPlayerCastController: GCKSessionManagerListener {
     }
 
     @objc func sessionManager(_ sessionManager: GCKSessionManager, didResumeSession session: GCKSession) {
-        loadMediaIfCastSessionAvailable()
+        resumeCastSession(session)
     }
 
     @objc func sessionManager(_ sessionManager: GCKSessionManager, didEnd session: GCKSession, withError error: Error?) {

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerCastController.swift
@@ -220,7 +220,10 @@ private extension VideoPlayerCastController {
             return
         }
 
-        let overlayView = playerViewController.view
+        guard let overlayView = playerViewController.view else {
+            return
+        }
+
         overlayView.isUserInteractionEnabled = true
         let button = GCKUICastButton(frame: .zero)
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerPlugin.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerPlugin.swift
@@ -76,7 +76,6 @@ extension VideoPlayerPlugin {
         let pipEnabled = call.getBool("pipEnabled") ?? true
         let showControls = call.getBool("showControls") ?? true
         let chromecast = call.getBool("chromecast") ?? true
-        let chromecastReceiverAppId = call.getString("chromecastReceiverAppId")
         let title = call.getString("title")
         let smallTitle = call.getString("smallTitle")
         let artwork = call.getString("artwork")
@@ -97,7 +96,6 @@ extension VideoPlayerPlugin {
             pipEnabled: pipEnabled,
             showControls: showControls,
             chromecast: chromecast,
-            chromecastReceiverAppId: chromecastReceiverAppId,
             title: title,
             smallTitle: smallTitle,
             artwork: artwork,

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerPlugin.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerPlugin.swift
@@ -103,13 +103,6 @@ extension VideoPlayerPlugin {
             fairplayContentKeySpcUrl: fairplayContentKeySpcUrl
         )
 
-        player.setupPlayer()
-        configureCallbacks(for: player, playerId: playerId)
-
-        // Store player
-        videoPlayers[playerId] = player
-        currentPlayerId = playerId
-
         // Present player
         DispatchQueue.main.async {
             guard let viewController = self.bridge?.viewController else {
@@ -120,6 +113,13 @@ extension VideoPlayerPlugin {
                 ])
                 return
             }
+
+            player.setupPlayer()
+            self.configureCallbacks(for: player, playerId: playerId)
+
+            // Store player
+            self.videoPlayers[playerId] = player
+            self.currentPlayerId = playerId
 
             player.present(on: viewController) {
                 call.resolve([

--- a/ios/Sources/VideoPlayerPlugin/VideoPlayerPlugin.swift
+++ b/ios/Sources/VideoPlayerPlugin/VideoPlayerPlugin.swift
@@ -38,7 +38,9 @@ public class VideoPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func getPluginVersion(_ call: CAPPluginCall) {
         call.resolve(["version": self.pluginVersion])
     }
+}
 
+extension VideoPlayerPlugin {
     @objc func initPlayer(_ call: CAPPluginCall) {
         guard let playerId = call.getString("playerId") else {
             call.resolve([
@@ -73,6 +75,11 @@ public class VideoPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         let loopOnEnd = call.getBool("loopOnEnd") ?? false
         let pipEnabled = call.getBool("pipEnabled") ?? true
         let showControls = call.getBool("showControls") ?? true
+        let chromecast = call.getBool("chromecast") ?? true
+        let chromecastReceiverAppId = call.getString("chromecastReceiverAppId")
+        let title = call.getString("title")
+        let smallTitle = call.getString("smallTitle")
+        let artwork = call.getString("artwork")
 
         // Extract FairPlay DRM options if provided
         let drm = call.getObject("drm")
@@ -89,13 +96,44 @@ public class VideoPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             loopOnEnd: loopOnEnd,
             pipEnabled: pipEnabled,
             showControls: showControls,
+            chromecast: chromecast,
+            chromecastReceiverAppId: chromecastReceiverAppId,
+            title: title,
+            smallTitle: smallTitle,
+            artwork: artwork,
             fairplayCertificateUrl: fairplayCertificateUrl,
             fairplayContentKeySpcUrl: fairplayContentKeySpcUrl
         )
 
         player.setupPlayer()
+        configureCallbacks(for: player, playerId: playerId)
 
-        // Setup callbacks
+        // Store player
+        videoPlayers[playerId] = player
+        currentPlayerId = playerId
+
+        // Present player
+        DispatchQueue.main.async {
+            guard let viewController = self.bridge?.viewController else {
+                call.resolve([
+                    "result": false,
+                    "method": "initPlayer",
+                    "message": "Unable to get view controller"
+                ])
+                return
+            }
+
+            player.present(on: viewController) {
+                call.resolve([
+                    "result": true,
+                    "method": "initPlayer",
+                    "value": playerId
+                ])
+            }
+        }
+    }
+
+    private func configureCallbacks(for player: FullscreenVideoPlayer, playerId: String) {
         player.setOnPlay { [weak self] in
             self?.notifyListeners("jeepCapVideoPlayerPlay", data: [
                 "fromPlayerId": playerId,
@@ -133,30 +171,6 @@ public class VideoPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
                 "dismiss": true,
                 "currentTime": currentTime
             ])
-        }
-
-        // Store player
-        videoPlayers[playerId] = player
-        currentPlayerId = playerId
-
-        // Present player
-        DispatchQueue.main.async {
-            guard let viewController = self.bridge?.viewController else {
-                call.resolve([
-                    "result": false,
-                    "method": "initPlayer",
-                    "message": "Unable to get view controller"
-                ])
-                return
-            }
-
-            player.present(on: viewController) {
-                call.resolve([
-                    "result": true,
-                    "method": "initPlayer",
-                    "value": playerId
-                ])
-            }
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -198,11 +198,6 @@ export interface capVideoPlayerOptions {
    */
   chromecast?: boolean;
   /**
-   * iOS Chromecast receiver application ID.
-   * Defaults to the Google Cast default media receiver when omitted.
-   */
-  chromecastReceiverAppId?: string;
-  /**
    * Artwork url to be shown in Chromecast player (iOS, Android)
    * by Manuel García Marín (https://github.com/PhantomPainX)
    * default: ""

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -174,12 +174,12 @@ export interface capVideoPlayerOptions {
     [key: string]: string;
   };
   /**
-   * Title shown in the player (Android)
+   * Title shown in the player and Chromecast metadata (iOS, Android)
    * by Manuel García Marín (https://github.com/PhantomPainX)
    */
   title?: string;
   /**
-   * Subtitle shown below the title in the player (Android)
+   * Subtitle shown below the title in the player and Chromecast metadata (iOS, Android)
    * by Manuel García Marín (https://github.com/PhantomPainX)
    */
   smallTitle?: string;
@@ -191,13 +191,19 @@ export interface capVideoPlayerOptions {
    */
   accentColor?: string;
   /**
-   * Chromecast enable/disable (Android)
+   * Chromecast enable/disable (iOS, Android)
+   * iOS requires Google Cast SDK setup and local network Info.plist keys.
    * by Manuel García Marín (https://github.com/PhantomPainX)
    * default: true
    */
   chromecast?: boolean;
   /**
-   * Artwork url to be shown in Chromecast player
+   * iOS Chromecast receiver application ID.
+   * Defaults to the Google Cast default media receiver when omitted.
+   */
+  chromecastReceiverAppId?: string;
+  /**
+   * Artwork url to be shown in Chromecast player (iOS, Android)
    * by Manuel García Marín (https://github.com/PhantomPainX)
    * default: ""
    */


### PR DESCRIPTION
## What
- Add iOS Chromecast sender support to the native fullscreen video player.
- Add Google Cast SDK dependencies for CocoaPods and Swift Package Manager.
- Document iOS Cast setup for the Google Cast default media receiver and `chromecast: true` usage.

## Why
- Fixes #28 by bringing Chromecast support to iOS instead of Android only.

## How
- Add a Cast controller around `AVPlayerViewController` that renders a Cast button, loads the current media on the default Cast receiver, and routes playback controls to the remote media client while casting.
- Keep the API simple: no custom receiver app ID is exposed or required.
- Preserve local playback position when entering and leaving Cast sessions.
- Reattach to resumed Cast sessions without reloading or restarting the receiver stream.
- Use existing `title`, `smallTitle`, and `artwork` metadata for Cast media information.

## Testing
- `bun run swiftlint -- lint`
- iOS SwiftPM build for `arm64-apple-ios15.0`
- `bun run verify`
- GitHub Actions: `Build code and test`, `build_ios`, `build_android`, `guard_swiftpm_version`, Socket checks, and CodeRabbit pass on the latest commit.

## Not Tested
- Real iOS device Chromecast session with physical Cast hardware.